### PR TITLE
an operator file to allow setting the external URL value for prometheus.

### DIFF
--- a/manifests/operators/prometheus-web-external-url.yml
+++ b/manifests/operators/prometheus-web-external-url.yml
@@ -1,0 +1,7 @@
+- type: replace
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/web?/external_url?
+  value: ((prometheus_web_external_url))
+
+- type: replace
+  path: /instance_groups/name=grafana/jobs/name=grafana/properties/grafana/prometheus?/use_external_url?
+  value: false


### PR DESCRIPTION
The primary reason for adding this is to make the "source" link on alerts in Alert Manager take you to the web accessible URL for prometheus.   
By default it tries to take you to a URL with the BOSH instance-group id of the prometheus node which isn't too helpful.