### PR TITLE
Give the test alert a name

### DIFF
--- a/jobs/alertmanager/templates/bin/alertmanager_test
+++ b/jobs/alertmanager/templates/bin/alertmanager_test
@@ -3,5 +3,5 @@
 set -eu
 
 curl -H "Content-Type: application/json" \
-  -d '[{"labels":{"service":"alertmanager","severity":"warning"},"annotations":{"summary":"Alertmanager `<%= spec.name %>/<%= spec.index %>` test","description":"This is a test alert from alertmanager `<%= spec.name %>/<%= spec.index %>`"}}]' \
+  -d '[{"labels":{"alertname":"TestAlert","service":"alertmanager","severity":"warning"},"annotations":{"summary":"Alertmanager `<%= spec.name %>/<%= spec.index %>` test","description":"This is a test alert from alertmanager `<%= spec.name %>/<%= spec.index %>`"}}]' \
   <%= spec.ip %>:<%= p('alertmanager.web.port') %>/api/v1/alerts


### PR DESCRIPTION
The test alert is missing a name. I hardcoded it to "TestAlert". If necessary I can add a new variable to allow customization.