### PR TITLE
Fix Elasticsearch alerts

### DIFF
--- a/jobs/elasticsearch_alerts/templates/cluster.alerts
+++ b/jobs/elasticsearch_alerts/templates/cluster.alerts
@@ -44,6 +44,6 @@ ALERT ElasticHeapUsage
     severity = "warning",
   }
   ANNOTATIONS {
-    summary = "Heap usage on node `{{$labels.cluster}}/{{$name}}` has been over <%= p('elasticsearch_alerts.heap_usage.threshold') %> for a long time",
-    description = "Heap usage on node `{{$labels.cluster}}/{{$name}}` has been over <%= p('elasticsearch_alerts.heap_usage.threshold') %> for <%= p('elasticsearch_alerts.heap_usage.evaluation_time') %>",
+    summary = "Heap usage on node `{{$labels.cluster}}/{{$labels.name}}` has been over <%= p('elasticsearch_alerts.heap_usage.threshold') %> for a long time",
+    description = "Heap usage on node `{{$labels.cluster}}/{{$labels.name}}` has been over <%= p('elasticsearch_alerts.heap_usage.threshold') %> for <%= p('elasticsearch_alerts.heap_usage.evaluation_time') %>",
   }


### PR DESCRIPTION
ElasticHeapUsage alert tries to reference the "name" label, without accessing the "labels" maps. This lead to this message:

```
msg="Error expanding alert template ElasticHeapUsage with data '{map[cluster:logsearch
 instance:logsearch bosh:bosh job:logsearch area:heap host:192.168.0.1 name:elasticsearch_data/0] 0.93169611788588
56}': runtime error: invalid memory address or nil pointer dereference" source="alerting.go:200"
```