### PR TITLE
Increase Prometheus stop wait timeout

### DIFF
--- a/jobs/prometheus/templates/bin/prometheus_ctl
+++ b/jobs/prometheus/templates/bin/prometheus_ctl
@@ -128,7 +128,7 @@ case $1 in
     ;;
 
   stop)
-    kill_and_wait ${PIDFILE}
+    kill_and_wait ${PIDFILE} 60
     ;;
 
   *)


### PR DESCRIPTION
When you have a lot of metrics, Prometheus stopping process can take longer than the 25s default wait time of utils.sh. After this timeout, Prometheus is killed with a SIGKILL and when restarted it has to recover. This can take a looong time...

I increased the stop wait timeout to 60s in order to allow big Prometheus installation to shut down properly. If necessary, I can add a new variable to allow tuning of this timeout.