### PR TITLE
do not alert on bosh-health-check deployment

### DIFF
--- a/jobs/bosh_alerts/templates/bosh_jobs.alerts
+++ b/jobs/bosh_alerts/templates/bosh_jobs.alerts
@@ -1,5 +1,5 @@
 ALERT BOSHJobUnhealthy
-  IF max(bosh_job_healthy{bosh_job_name!~"^compilation.*"}) by(environment, bosh_name, bosh_deployment, bosh_job_name, bosh_job_index) < 1
+  IF max(bosh_job_healthy{bosh_job_name!~"^compilation.*",bosh_deployment!="bosh-health-check"}) by(environment, bosh_name, bosh_deployment, bosh_job_name, bosh_job_index) < 1
   FOR <%= p('bosh_alerts.job_unhealthy.evaluation_time') %>
   LABELS {
     service = "bosh-job",
@@ -11,7 +11,7 @@ ALERT BOSHJobUnhealthy
   }
 
 ALERT BOSHJobExtendedUnhealthy
-  IF max(bosh_job_healthy{bosh_job_name!~"^compilation.*"}) by(environment, bosh_name, bosh_deployment, bosh_job_name, bosh_job_index) < 1
+  IF max(bosh_job_healthy{bosh_job_name!~"^compilation.*",bosh_deployment!="bosh-health-check"}) by(environment, bosh_name, bosh_deployment, bosh_job_name, bosh_job_index) < 1
   FOR <%= p('bosh_alerts.job_extended_unhealthy.evaluation_time') %>
   LABELS {
     service = "bosh-job",

--- a/jobs/bosh_alerts/templates/bosh_processes.alerts
+++ b/jobs/bosh_alerts/templates/bosh_processes.alerts
@@ -1,5 +1,5 @@
 ALERT BOSHJobProcessUnhealthy
-  IF max(bosh_job_process_healthy{bosh_job_name!~"^compilation.*"}) by(environment, bosh_name, bosh_deployment, bosh_job_name, bosh_job_index, bosh_job_process_name) < 1
+  IF max(bosh_job_process_healthy{bosh_job_name!~"^compilation.*",bosh_deployment!="bosh-health-check"}) by(environment, bosh_name, bosh_deployment, bosh_job_name, bosh_job_index, bosh_job_process_name) < 1
   FOR <%= p('bosh_alerts.process_unhealthy.evaluation_time') %>
   LABELS {
     service = "bosh-job-process",
@@ -11,7 +11,7 @@ ALERT BOSHJobProcessUnhealthy
   }
 
 ALERT BOSHJobProcessExtendedUnhealthy
-  IF max(bosh_job_process_healthy{bosh_job_name!~"^compilation.*"}) by(environment, bosh_name, bosh_deployment, bosh_job_name, bosh_job_index, bosh_job_process_name) < 1
+  IF max(bosh_job_process_healthy{bosh_job_name!~"^compilation.*",bosh_deployment!="bosh-health-check"}) by(environment, bosh_name, bosh_deployment, bosh_job_name, bosh_job_index, bosh_job_process_name) < 1
   FOR <%= p('bosh_alerts.process_extended_unhealthy.evaluation_time') %>
   LABELS {
     service = "bosh-job-process",

--- a/jobs/bosh_alerts/templates/bosh_system.alerts
+++ b/jobs/bosh_alerts/templates/bosh_system.alerts
@@ -1,5 +1,5 @@
 ALERT BOSHJobHighCPULoad
-  IF avg(bosh_job_load_avg01{bosh_job_name!~"^compilation.*"}) by(environment, bosh_name, bosh_deployment, bosh_job_name, bosh_job_index) > <%= p('bosh_alerts.job_high_cpu_load.threshold') %>
+  IF avg(bosh_job_load_avg01{bosh_job_name!~"^compilation.*",bosh_deployment!="bosh-health-check"}) by(environment, bosh_name, bosh_deployment, bosh_job_name, bosh_job_index) > <%= p('bosh_alerts.job_high_cpu_load.threshold') %>
   FOR <%= p('bosh_alerts.job_high_cpu_load.evaluation_time') %>
   LABELS {
     service = "bosh-job",
@@ -11,7 +11,7 @@ ALERT BOSHJobHighCPULoad
   }
 
 ALERT BOSHJobLowFreeRAM
-  IF avg(bosh_job_mem_percent{bosh_job_name!~"^compilation.*"}) by(environment, bosh_name, bosh_deployment, bosh_job_name, bosh_job_index) > <%= p('bosh_alerts.job_low_free_ram.threshold') %>
+  IF avg(bosh_job_mem_percent{bosh_job_name!~"^compilation.*",bosh_deployment!="bosh-health-check"}) by(environment, bosh_name, bosh_deployment, bosh_job_name, bosh_job_index) > <%= p('bosh_alerts.job_low_free_ram.threshold') %>
   FOR <%= p('bosh_alerts.job_low_free_ram.evaluation_time') %>
   LABELS {
     service = "bosh-job",
@@ -23,7 +23,7 @@ ALERT BOSHJobLowFreeRAM
   }
 
 ALERT BOSHJobLowSwap
-  IF avg(bosh_job_swap_percent{bosh_job_name!~"^compilation.*"}) by(environment, bosh_name, bosh_deployment, bosh_job_name, bosh_job_index) > <%= p('bosh_alerts.job_low_swap.threshold') %>
+  IF avg(bosh_job_swap_percent{bosh_job_name!~"^compilation.*",bosh_deployment!="bosh-health-check"}) by(environment, bosh_name, bosh_deployment, bosh_job_name, bosh_job_index) > <%= p('bosh_alerts.job_low_swap.threshold') %>
   FOR <%= p('bosh_alerts.job_low_swap.evaluation_time') %>
   LABELS {
     service = "bosh-job",
@@ -35,7 +35,7 @@ ALERT BOSHJobLowSwap
   }
 
 ALERT BOSHJobSystemDiskFull
-  IF avg(bosh_job_system_disk_percent{bosh_job_name!~"^compilation.*"}) by(environment, bosh_name, bosh_deployment, bosh_job_name, bosh_job_index) > <%= p('bosh_alerts.job_system_disk_full.threshold') %>
+  IF avg(bosh_job_system_disk_percent{bosh_job_name!~"^compilation.*",bosh_deployment!="bosh-health-check"}) by(environment, bosh_name, bosh_deployment, bosh_job_name, bosh_job_index) > <%= p('bosh_alerts.job_system_disk_full.threshold') %>
   FOR <%= p('bosh_alerts.job_system_disk_full.evaluation_time') %>
   LABELS {
     service = "bosh-job",
@@ -47,7 +47,7 @@ ALERT BOSHJobSystemDiskFull
   }
 
 ALERT BOSHJobEphemeralDiskFull
-  IF avg(bosh_job_ephemeral_disk_percent{bosh_job_name!~"^compilation.*"}) by(environment, bosh_name, bosh_deployment, bosh_job_name, bosh_job_index) > <%= p('bosh_alerts.job_ephemeral_disk_full.threshold') %>
+  IF avg(bosh_job_ephemeral_disk_percent{bosh_job_name!~"^compilation.*",bosh_deployment!="bosh-health-check"}) by(environment, bosh_name, bosh_deployment, bosh_job_name, bosh_job_index) > <%= p('bosh_alerts.job_ephemeral_disk_full.threshold') %>
   FOR <%= p('bosh_alerts.job_ephemeral_disk_full.evaluation_time') %>
   LABELS {
     service = "bosh-job",
@@ -59,7 +59,7 @@ ALERT BOSHJobEphemeralDiskFull
   }
 
 ALERT BOSHJobPersistentDiskFull
-  IF avg(bosh_job_persistent_disk_percent{bosh_job_name!~"^compilation.*"}) by(environment, bosh_name, bosh_deployment, bosh_job_name, bosh_job_index) > <%= p('bosh_alerts.job_persistent_disk_full.threshold') %>
+  IF avg(bosh_job_persistent_disk_percent{bosh_job_name!~"^compilation.*",bosh_deployment!="bosh-health-check"}) by(environment, bosh_name, bosh_deployment, bosh_job_name, bosh_job_index) > <%= p('bosh_alerts.job_persistent_disk_full.threshold') %>
   FOR <%= p('bosh_alerts.job_persistent_disk_full.evaluation_time') %>
   LABELS {
     service = "bosh-job",
@@ -71,7 +71,7 @@ ALERT BOSHJobPersistentDiskFull
   }
 
 ALERT BOSHJobPersistentDiskInodesExhausted
-  IF avg(bosh_job_persistent_disk_inode_percent{bosh_job_name!~"^compilation.*"}) by(environment, bosh_name, bosh_deployment, bosh_job_name, bosh_job_index) > <%= p('bosh_alerts.job_persistent_disk_inodes_exhausted.threshold') %>
+  IF avg(bosh_job_persistent_disk_inode_percent{bosh_job_name!~"^compilation.*",bosh_deployment!="bosh-health-check"}) by(environment, bosh_name, bosh_deployment, bosh_job_name, bosh_job_index) > <%= p('bosh_alerts.job_persistent_disk_inodes_exhausted.threshold') %>
   FOR <%= p('bosh_alerts.job_persistent_disk_inodes_exhausted.evaluation_time') %>
   LABELS {
     service = "bosh-job",

--- a/jobs/bosh_alerts/templates/bosh_system_predict.alerts
+++ b/jobs/bosh_alerts/templates/bosh_system_predict.alerts
@@ -1,5 +1,5 @@
 ALERT BOSHJobSystemDiskPredictWillFill
-  IF predict_linear(bosh_job_system_disk_percent{bosh_job_name!~"^compilation.*"}[1h], <%= p('bosh_alerts.job_predict_system_disk_full.predict_time') %>) > <%= p('bosh_alerts.job_predict_system_disk_full.threshold') %>
+  IF predict_linear(bosh_job_system_disk_percent{bosh_job_name!~"^compilation.*",bosh_deployment!="bosh-health-check"}[1h], <%= p('bosh_alerts.job_predict_system_disk_full.predict_time') %>) > <%= p('bosh_alerts.job_predict_system_disk_full.threshold') %>
   FOR <%= p('bosh_alerts.job_predict_system_disk_full.evaluation_time') %>
   LABELS {
     service = "bosh-job",
@@ -23,7 +23,7 @@ ALERT BOSHJobSystemDiskPredictWillFill
   }
 
   ALERT BOSHJobPersistentDiskPredictWillFill
-  IF predict_linear(bosh_job_persistent_disk_percent{bosh_job_name!~"^compilation.*"}[1h], <%= p('bosh_alerts.job_predict_persistent_disk_full.predict_time') %>) > <%= p('bosh_alerts.job_predict_persistent_disk_full.threshold') %>
+  IF predict_linear(bosh_job_persistent_disk_percent{bosh_job_name!~"^compilation.*",bosh_deployment!="bosh-health-check"}[1h], <%= p('bosh_alerts.job_predict_persistent_disk_full.predict_time') %>) > <%= p('bosh_alerts.job_predict_persistent_disk_full.threshold') %>
   FOR <%= p('bosh_alerts.job_predict_persistent_disk_full.evaluation_time') %>
   LABELS {
     service = "bosh-job",

--- a/jobs/bosh_alerts/templates/bosh_tsdb_jobs.alerts
+++ b/jobs/bosh_alerts/templates/bosh_tsdb_jobs.alerts
@@ -1,5 +1,5 @@
 ALERT BOSHTSDBJobUnhealthy
-  IF max(bosh_tsdb_job_healthy{bosh_job_name!~"^compilation.*"}) by(environment, bosh_deployment, bosh_job_name, bosh_job_index) < 1
+  IF max(bosh_tsdb_job_healthy{bosh_job_name!~"^compilation.*",bosh_deployment!="bosh-health-check"}) by(environment, bosh_deployment, bosh_job_name, bosh_job_index) < 1
   FOR <%= p('bosh_alerts.job_unhealthy.evaluation_time') %>
   LABELS {
     service = "bosh-job",
@@ -11,7 +11,7 @@ ALERT BOSHTSDBJobUnhealthy
   }
 
 ALERT BOSHTSDBJobExtendedUnhealthy
-  IF max(bosh_tsdb_job_healthy{bosh_job_name!~"^compilation.*"}) by(environment, bosh_deployment, bosh_job_name, bosh_job_index) < 1
+  IF max(bosh_tsdb_job_healthy{bosh_job_name!~"^compilation.*",bosh_deployment!="bosh-health-check"}) by(environment, bosh_deployment, bosh_job_name, bosh_job_index) < 1
   FOR <%= p('bosh_alerts.job_extended_unhealthy.evaluation_time') %>
   LABELS {
     service = "bosh-job",

--- a/jobs/bosh_alerts/templates/bosh_tsdb_system.alerts
+++ b/jobs/bosh_alerts/templates/bosh_tsdb_system.alerts
@@ -1,5 +1,5 @@
 ALERT BOSHTSDBJobHighCPULoad
-  IF avg(bosh_tsdb_job_load_avg01{bosh_job_name!~"^compilation.*"}) by(environment, bosh_deployment, bosh_job_name, bosh_job_index) > <%= p('bosh_alerts.job_high_cpu_load.threshold') %>
+  IF avg(bosh_tsdb_job_load_avg01{bosh_job_name!~"^compilation.*",bosh_deployment!="bosh-health-check"}) by(environment, bosh_deployment, bosh_job_name, bosh_job_index) > <%= p('bosh_alerts.job_high_cpu_load.threshold') %>
   FOR <%= p('bosh_alerts.job_high_cpu_load.evaluation_time') %>
   LABELS {
     service = "bosh-job",
@@ -11,7 +11,7 @@ ALERT BOSHTSDBJobHighCPULoad
   }
 
 ALERT BOSHTSDBJobLowFreeRAM
-  IF avg(bosh_tsdb_job_mem_percent{bosh_job_name!~"^compilation.*"}) by(environment, bosh_deployment, bosh_job_name, bosh_job_index) > <%= p('bosh_alerts.job_low_free_ram.threshold') %>
+  IF avg(bosh_tsdb_job_mem_percent{bosh_job_name!~"^compilation.*",bosh_deployment!="bosh-health-check"}) by(environment, bosh_deployment, bosh_job_name, bosh_job_index) > <%= p('bosh_alerts.job_low_free_ram.threshold') %>
   FOR <%= p('bosh_alerts.job_low_free_ram.evaluation_time') %>
   LABELS {
     service = "bosh-job",
@@ -23,7 +23,7 @@ ALERT BOSHTSDBJobLowFreeRAM
   }
 
 ALERT BOSHTSDBJobLowSwap
-  IF avg(bosh_tsdb_job_swap_percent{bosh_job_name!~"^compilation.*"}) by(environment, bosh_deployment, bosh_job_name, bosh_job_index) > <%= p('bosh_alerts.job_low_swap.threshold') %>
+  IF avg(bosh_tsdb_job_swap_percent{bosh_job_name!~"^compilation.*",bosh_deployment!="bosh-health-check"}) by(environment, bosh_deployment, bosh_job_name, bosh_job_index) > <%= p('bosh_alerts.job_low_swap.threshold') %>
   FOR <%= p('bosh_alerts.job_low_swap.evaluation_time') %>
   LABELS {
     service = "bosh-job",
@@ -35,7 +35,7 @@ ALERT BOSHTSDBJobLowSwap
   }
 
 ALERT BOSHTSDBJobSystemDiskFull
-  IF avg(bosh_tsdb_job_system_disk_percent{bosh_job_name!~"^compilation.*"}) by(environment, bosh_deployment, bosh_job_name, bosh_job_index) > <%= p('bosh_alerts.job_system_disk_full.threshold') %>
+  IF avg(bosh_tsdb_job_system_disk_percent{bosh_job_name!~"^compilation.*",bosh_deployment!="bosh-health-check"}) by(environment, bosh_deployment, bosh_job_name, bosh_job_index) > <%= p('bosh_alerts.job_system_disk_full.threshold') %>
   FOR <%= p('bosh_alerts.job_system_disk_full.evaluation_time') %>
   LABELS {
     service = "bosh-job",
@@ -47,7 +47,7 @@ ALERT BOSHTSDBJobSystemDiskFull
   }
 
 ALERT BOSHTSDBJobEphemeralDiskFull
-  IF avg(bosh_tsdb_job_ephemeral_disk_percent{bosh_job_name!~"^compilation.*"}) by(environment, bosh_deployment, bosh_job_name, bosh_job_index) > <%= p('bosh_alerts.job_ephemeral_disk_full.threshold') %>
+  IF avg(bosh_tsdb_job_ephemeral_disk_percent{bosh_job_name!~"^compilation.*",bosh_deployment!="bosh-health-check"}) by(environment, bosh_deployment, bosh_job_name, bosh_job_index) > <%= p('bosh_alerts.job_ephemeral_disk_full.threshold') %>
   FOR <%= p('bosh_alerts.job_ephemeral_disk_full.evaluation_time') %>
   LABELS {
     service = "bosh-job",
@@ -59,7 +59,7 @@ ALERT BOSHTSDBJobEphemeralDiskFull
   }
 
 ALERT BOSHTSDBJobPersistentDiskFull
-  IF avg(bosh_tsdb_job_persistent_disk_percent{bosh_job_name!~"^compilation.*"}) by(environment, bosh_deployment, bosh_job_name, bosh_job_index) > <%= p('bosh_alerts.job_persistent_disk_full.threshold') %>
+  IF avg(bosh_tsdb_job_persistent_disk_percent{bosh_job_name!~"^compilation.*",bosh_deployment!="bosh-health-check"}) by(environment, bosh_deployment, bosh_job_name, bosh_job_index) > <%= p('bosh_alerts.job_persistent_disk_full.threshold') %>
   FOR <%= p('bosh_alerts.job_persistent_disk_full.evaluation_time') %>
   LABELS {
     service = "bosh-job",

--- a/jobs/bosh_alerts/templates/bosh_tsdb_system_predict.alerts
+++ b/jobs/bosh_alerts/templates/bosh_tsdb_system_predict.alerts
@@ -1,5 +1,5 @@
 ALERT BOSHTSDBJobSystemDiskPredictWillFill
-  IF predict_linear(bosh_tsdb_job_system_disk_percent{bosh_job_name!~"^compilation.*"}[1h], <%= p('bosh_alerts.job_predict_system_disk_full.predict_time') %>) > <%= p('bosh_alerts.job_predict_system_disk_full.threshold') %>
+  IF predict_linear(bosh_tsdb_job_system_disk_percent{bosh_job_name!~"^compilation.*",bosh_deployment!="bosh-health-check"}[1h], <%= p('bosh_alerts.job_predict_system_disk_full.predict_time') %>) > <%= p('bosh_alerts.job_predict_system_disk_full.threshold') %>
   FOR <%= p('bosh_alerts.job_predict_system_disk_full.evaluation_time') %>
   LABELS {
     service = "bosh-job",
@@ -23,7 +23,7 @@ ALERT BOSHTSDBJobEphemeralDiskPredictWillFill
   }
 
 ALERT BOSHTSDBJobPersistentDiskPredictWillFill
-  IF predict_linear(bosh_tsdb_job_persistent_disk_percent{bosh_job_name!~"^compilation.*"}[1h], <%= p('bosh_alerts.job_predict_persistent_disk_full.predict_time') %>) > <%= p('bosh_alerts.job_predict_persistent_disk_full.threshold') %>
+  IF predict_linear(bosh_tsdb_job_persistent_disk_percent{bosh_job_name!~"^compilation.*",bosh_deployment!="bosh-health-check"}[1h], <%= p('bosh_alerts.job_predict_persistent_disk_full.predict_time') %>) > <%= p('bosh_alerts.job_predict_persistent_disk_full.threshold') %>
   FOR <%= p('bosh_alerts.job_predict_persistent_disk_full.evaluation_time') %>
   LABELS {
     service = "bosh-job",


### PR DESCRIPTION
Recently released PCF Healthwatch tile includes a BOSH Director smoke test which deploys a new VM every 10 minutes. This triggers alerts as this VM is considered unhealthy. Currently the name of the deployment, bosh-health-check, is hardcoded so it's easy to exclude it. If it becomes configurable in the future we may need to change this into a regexp configurable in the manifest.