### PR TITLE
Use lrp_failed_auction metric for lrp failed auction alert

### DIFF
--- a/jobs/cloudfoundry_alerts/templates/cf_diego.alerts
+++ b/jobs/cloudfoundry_alerts/templates/cf_diego.alerts
@@ -1,5 +1,5 @@
 ALERT CFLRPAuctionsFailedTooHigh
-  IF avg(irate(firehose_counter_event_auctioneer_auctioneer_lrp_auctions_started_total[5m])) by(environment, bosh_deployment) > <%= p('cloudfoundry_alerts.lrp_auctions_failed.threshold') %>
+  IF avg(irate(firehose_counter_event_auctioneer_auctioneer_lrp_auctions_failed_total[5m])) by(environment, bosh_deployment) > <%= p('cloudfoundry_alerts.lrp_auctions_failed.threshold') %>
   FOR <%= p('cloudfoundry_alerts.lrp_auctions_failed.evaluation_time') %>
   LABELS {
     service = "cf",


### PR DESCRIPTION
Use `firehose_counter_event_auctioneer_auctioneer_lrp_auctions_failed_total` for `CFLRPAuctionsFailedTooHigh` alert.

cc @jmcarp 