### PR TITLE
make nginx remove url path for grafana

### DIFF
--- a/jobs/nginx/templates/config/grafana_location.conf
+++ b/jobs/nginx/templates/config/grafana_location.conf
@@ -1,5 +1,5 @@
 location <%= p('nginx.grafana.path') %> {
-    proxy_pass            http://grafana;
+    proxy_pass            http://grafana/;
     <% if p('nginx.ssl_only') %>
     proxy_redirect        http:// https://;
     <% end %>


### PR DESCRIPTION
Grafana seems to ignore path information in root_url for it's own internal router. Using an URL path hence breaks Grafana. Nginx has to remove the path, see also Grafana documentation at https://github.com/grafana/grafana/blob/master/docs/sources/installation/behind_proxy.md .