### PR TITLE
adding long term storage of metrics using influxdb

### DIFF
--- a/jobs/prometheus/spec
+++ b/jobs/prometheus/spec
@@ -20,6 +20,9 @@ consumes:
   - name: alertmanager
     type: alertmanager
     optional: true
+  - name: influxdb
+    type: influxdb
+    optional: true
 
 properties:
   prometheus.log_format:

--- a/jobs/prometheus/templates/config/prometheus.yml
+++ b/jobs/prometheus/templates/config/prometheus.yml
@@ -27,6 +27,19 @@ scrape_configs: <%= p('prometheus.scrape_configs', []).to_json %>
 # Alerting specifies settings related to the Alertmanager.
 alerting: <%= p('prometheus.alerting', {}).to_json %>
 
+<%
+  if_link('influxdb') do |influxdb_link|
+    influxdb_host     = influxdb_link.instances.first.address
+    influxdb_database = influxdb_link.p("influxdb.database")
+    influxdb_username = influxdb_link.p("influxdb.user")
+    influxdb_password = influxdb_link.p("influxdb.password")
+
+    p('prometheus.remote_write')[0][:url] = "http://#{influxdb_host}:8086/api/v1/prom/write?db=#{influxdb_database}&u=#{influxdb_username}&p=#{influxdb_password}"
+    p('prometheus.remote_read')[0][:url] = "http://#{influxdb_host}:8086/api/v1/prom/read?db=#{influxdb_database}&u=#{influxdb_username}&p=#{influxdb_password}"
+
+  end
+%>
+
 <% if_p('prometheus.remote_write') do |remote_write| %>
 # Settings related to the experimental remote write feature.
 remote_write: <%= remote_write.to_json %>

--- a/manifests/operators/long-term-storage-influxdb.yml
+++ b/manifests/operators/long-term-storage-influxdb.yml
@@ -1,0 +1,54 @@
+---
+
+# fork of https://github.com/concourse/influxdb-boshrelease
+# includes influxdb 1.4.3 (prometheus support) and bosh linking
+- type: replace
+  path: /releases/-
+  value:
+    name: influxdb
+    version: 0.1.0-govau
+    sha1: c58eecf07c3d86138bb59453b07f78642fd84328
+    url: https://github.com/govau/influxdb-boshrelease/releases/download/v0.1.0-govau/influxdb-0.1.0-govau.tgz
+
+- type: replace
+  path: /instance_groups/-
+  value:
+    name: influxdb
+    azs:
+      - z1
+    instances: 1
+    vm_type: default
+    persistent_disk: 10_240
+    stemcell: default
+    networks:
+      - name: default
+    jobs:
+      - name: influxdb
+        release: influxdb
+        provides:
+          influxdb: {as: influxdb}
+        properties:
+          influxdb:
+            database: prometheus
+            user: ((influxdb_user.username))
+            password: ((influxdb_user.password))
+            retention: 30d
+
+# set a key/value in remote_write to help with BOSH template `prometheus.yml`
+- type: replace
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/remote_write?/-
+  value:
+    remote_timeout: 30s
+
+# set a key/value in remote_read to help with BOSH template `prometheus.yml`
+- type: replace
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/remote_read?/-
+  value:
+    remote_timeout: 30s
+
+# Influxdb username/password
+- type: replace
+  path: /variables/-
+  value:
+    name: influxdb_user
+    type: user


### PR DESCRIPTION
raised in #165 - add long term storage for prometheus using influxdb.
perhaps there's a nicer way to deal with the `remote_write` and `remote_read` values in `prometheus.yml`.

can be tested with 
```
bosh create-release --force
bosh upload-release
bosh deploy -d prometheus manifests/prometheus.yml \
-o manifests/operators/long-term-storage-influxdb.yml \
-o manifests/operators/dev/latest-prometheus-release.yml  -n
```
```
bosh ssh -d prometheus influxdb
$ /var/vcap/packages/influxdb/influx
Connected to http://localhost:8086 version 1.4.3
InfluxDB shell version: 1.4.3
> show databases
name: databases
name
----
prometheus
_internal
> use prometheus
Using database prometheus
> show series
...
...
```