### PR TITLE
Patch netcat command to make it compatible with CentOS stemcell

### DIFF
--- a/jobs/grafana/templates/bin/grafana-admin-password
+++ b/jobs/grafana/templates/bin/grafana-admin-password
@@ -5,7 +5,7 @@ set -eu
 retries=60
 for ((i=0; i<=retries; i++)); do
   echo "Waiting for grafana to listen on port <%= p('grafana.server.http_port') %> ($i/$retries)"
-  if nc -z 127.0.0.1 <%= p('grafana.server.http_port') %>; then
+  if nc 127.0.0.1 <%= p('grafana.server.http_port') %> < /dev/null; then
     echo "Grafana is ready"
     break
   fi


### PR DESCRIPTION
netcat (nc command) "-z" option does not exist with RedHat/CentOS distribtions to test TCP port availability. 

Remove "-z" option and provide "/dev/null" as command input. Patch works for both Utuntu and CentOS stemcells.