### PR TITLE
Make cf_exporter client read only

### DIFF
--- a/manifests/operators/cf/add-prometheus-uaa-clients.yml
+++ b/manifests/operators/cf/add-prometheus-uaa-clients.yml
@@ -6,8 +6,8 @@
   value:
     override: true
     authorized-grant-types: client_credentials,refresh_token
-    authorities: cloud_controller.admin
-    scope: openid,cloud_controller.admin
+    authorities: cloud_controller.admin_read_only
+    scope: openid,cloud_controller.admin_read_only
     secret: "((uaa_clients_cf_exporter_secret))"
 
 - type: replace


### PR DESCRIPTION
`cloud_controller.admin_read_only` seems to be safer for cf_exporter.