### PR TITLE
Fixes expr for unassigned shards and for node count

### DIFF
--- a/jobs/elasticsearch_dashboards/templates/elasticsearch.json
+++ b/jobs/elasticsearch_dashboards/templates/elasticsearch.json
@@ -286,7 +286,7 @@
           },
           "targets": [
             {
-              "expr": "elasticsearch_cluster_health_number_of_data_nodes{instance=\"$instance\"}",
+              "expr": "elasticsearch_cluster_health_number_of_nodes{instance=\"$instance\"}",
               "interval": "",
               "intervalFactor": 2,
               "legendFormat": "",
@@ -860,7 +860,7 @@
           },
           "targets": [
             {
-              "expr": "elasticsearch_cluster_health_delayed_unassigned_shards{instance=\"$instance\"}",
+              "expr": "elasticsearch_cluster_health_unassigned_shards{instance=\"$instance\"}",
               "intervalFactor": 2,
               "legendFormat": "",
               "refId": "A",


### PR DESCRIPTION
Now shows the correct values for Number of Nodes and Unassigned shards in grafana for elastic search metrics.