### PR TITLE
Add alarm for queue depth on p_rabbitmq_alerts

### DIFF
--- a/jobs/p_rabbitmq_alerts/spec
+++ b/jobs/p_rabbitmq_alerts/spec
@@ -26,3 +26,7 @@ properties:
   p_rabbitmq_alerts.sb_odb_no_instances.evaluation_time:
     description: "Service Broker On Demand no instances alert evaluation time"
     default: 30m
+  p_rabbitmq_alerts.queue_depth.warning:
+    description: "Warning threshold for queue depth"
+  p_rabbitmq_alerts.queue_depth.critical:
+    description: "Critical threshold for queue depth"

--- a/jobs/p_rabbitmq_alerts/templates/p_rabbitmq.alerts
+++ b/jobs/p_rabbitmq_alerts/templates/p_rabbitmq.alerts
@@ -33,3 +33,28 @@ ALERT PRabbitMQServiceBrokerDown
     summary = "Rabbitmq for PCF Service Broker instance `{{$labels.environment}}/{{$labels.bosh_deployment}}/{{$labels.bosh_job_name}}/{{$labels.bosh_job_ip}}` is down",
     description = "The RabbitMQ Service Broker instance at `{{$labels.environment}}/{{$labels.bosh_deployment}}/{{$labels.bosh_job_name}}/{{$labels.bosh_job_ip}}` has been down for the last <%= p('p_rabbitmq_alerts.service_broker_down.evaluation_time') %>",
   }
+
+<% if_p("p_rabbitmq_alerts.queue_depth.warning") do |threshold|  -%>
+ALERT RabbitMQQueueDepth
+  IF avg(firehose_value_metric_p_rabbitmq_p_rabbitmq_rabbitmq_messages_depth) by(environment) >= <%= threshold %>
+  LABELS {
+    service = "rabbitmq",
+    severity = "warning",
+  }
+  ANNOTATIONS {
+    summary = "RabbitMQ Queue depth WARNING",
+    description = "The RabbitMQ Queue depth is above <%= threshold %> messages"
+  }
+<% end -%>
+<% if_p("p_rabbitmq_alerts.queue_depth.critical") do |threshold|  -%>
+ALERT RabbitMQQueueDepth
+  IF avg(firehose_value_metric_p_rabbitmq_p_rabbitmq_rabbitmq_messages_depth) by(environment) >= <%= threshold %>
+  LABELS {
+    service = "rabbitmq",
+    severity = "critical",
+  }
+  ANNOTATIONS {
+    summary = "RabbitMQ Queue depth CRITICAL",
+    description = "The RabbitMQ Queue depth is above <%= threshold %> messages"
+  }
+<% end -%>


### PR DESCRIPTION
Adds the `p_rabbitmq_alerts.queue_depth.warning` and `p_rabbitmq_alerts.queue_depth.critical` properties to `p_rabbitmq_alerts` for optional alerts on RabbitMQ queue depth.