### PR TITLE
Update CF app request rate to avg over timewindows vs sum

### DIFF
--- a/jobs/cloudfoundry_dashboards/templates/cf_apps_requests.json
+++ b/jobs/cloudfoundry_dashboards/templates/cf_apps_requests.json
@@ -89,7 +89,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}[5m]))",
+              "expr": "avg(rate(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}[5m]))",
               "intervalFactor": 2,
               "legendFormat": "Requests",
               "refId": "A",


### PR DESCRIPTION
Request/sec graph was summing the rate for a consolidation window, which led to numbers changing depending on how zoomed in or out the graph was. This should get the avg rate for the window and be more accurate/consistent