### PR TITLE
Set send_resolved=true for prometheus alerting

### DIFF
--- a/manifests/operators/alertmanager-slack-receiver.yml
+++ b/manifests/operators/alertmanager-slack-receiver.yml
@@ -3,3 +3,4 @@
   value:
     api_url: "((alertmanager_slack_api_url))"
     channel: "((alertmanager_slack_channel))"
+    send_resolved: true


### PR DESCRIPTION
`send_resolved` is `false` by default for only [slack](https://prometheus.io/docs/alerting/configuration/#%3Cslack_config%3E) (and [email](https://prometheus.io/docs/alerting/configuration/#%3Cemail_config%3E) which is missing at this moment)

All users I have ever met are expecting sending resolved.

If changing this default is not preferable, I would make a pr for another ops-file like 

``` yaml
- type: replace
  path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties/alertmanager/receivers/name=default/slack_configs/0/send_resolved?
  value: true
```