### PR TITLE
Drop unused `--in-cluster` flag.

### DIFF
--- a/jobs/kube_state_metrics_exporter/templates/bin/kube_state_metrics_exporter_ctl
+++ b/jobs/kube_state_metrics_exporter/templates/bin/kube_state_metrics_exporter_ctl
@@ -41,7 +41,6 @@ case $1 in
       <% if_p('kube_state_metrics_exporter.collectors') do |collectors| %> \
       --collectors="<%= collectors %>" \
       <% end %> \
-      --in-cluster=false \
       --kubeconfig="/var/vcap/jobs/kube_state_metrics_exporter/config/kubeconfig" \
       <% if_p('kube_state_metrics_exporter.log_backtrace_at') do |log_backtrace_at| %> \
       --log_backtrace_at="<%= log_backtrace_at %>" \


### PR DESCRIPTION
As of https://github.com/kubernetes/kube-state-metrics/pull/371, the
`--in-cluster` flag is unsupported. Passing this flag now causes
`kube-state-metrics` to error.