### PR TITLE
Fix az name in the prometheus v1 migration ops file

### DIFF
--- a/manifests/operators/migrations/migrate_from_prometheus_1.yml
+++ b/manifests/operators/migrations/migrate_from_prometheus_1.yml
@@ -6,7 +6,7 @@
   value:
     name: prometheus
     azs:
-      - az-1
+      - z1
     instances: 1
     vm_type: default
     persistent_disk: 10_240


### PR DESCRIPTION
The az name in the prometheus v1 migration ops file differs from the default az name used in prometheus.yml. This is just bringing them inline, to reduce the need for extra ops files/cloud config when using the migration instance groups.