### PR TITLE
nginx_client_header_buffers

### DIFF
--- a/jobs/nginx/spec
+++ b/jobs/nginx/spec
@@ -40,6 +40,15 @@ properties:
   nginx.worker_connections:
     description: "Number of Nginx connections per worker"
     default: 8192
+  nginx.large_client_header_buffers.number:
+    description: "Sets the maximum number of buffers used for reading large client request header"
+    default: 4
+  nginx.large_client_header_buffers.size:
+    description: "Sets the maximum size of buffers used for reading large client request header"
+    default: 8k
+  nginx.client_header_buffer_size:
+    description: "Sets buffer size for reading client request header"
+    default: 1k
   nginx.max_upload_size:
     description: "File upload maximum size"
     default: 5000m

--- a/jobs/nginx/templates/config/nginx.conf
+++ b/jobs/nginx/templates/config/nginx.conf
@@ -22,6 +22,13 @@ http {
   tcp_nopush  on;
   tcp_nodelay on;
 
+  <% if_p('nginx.client_header_buffer_size') do |client_header_buffer_size| %>
+  client_header_buffer_size <%= client_header_buffer_size %>;
+  <% end %>
+  <% if_p('nginx.large_client_header_buffers.number', 'nginx.large_client_header_buffers.size') do |number, size| %>
+  large_client_header_buffers <%= number %> <%= size %>;
+  <% end %>
+  
   types_hash_max_size 2048;
 
   send_timeout 2;


### PR DESCRIPTION
add client_header_buffers parameters to fix 413 (Request Entity Too Large) error is returned to the client.
get this error with Grafana Request. 