### PR TITLE
add external-lb-from-cloud-config opsfile

### DIFF
--- a/manifests/operators/external-lb-from-cloud-config.yml
+++ b/manifests/operators/external-lb-from-cloud-config.yml
@@ -1,0 +1,19 @@
+---
+- type: replace
+  path: /instance_groups/name=nginx/vm_extensions?
+  value:
+  - prometheus-nginx-network-properties
+
+## if you add a vm extension to your cloud-config, you can attach lbs in an iaas-agnostic way:
+## for example, adding the following to an AWS cloud-config might wire
+## up your nginx vm to an externally provisioned elb with the appropriate target groups:
+#
+# vm_extensions:
+#   - name: prometheus-nginx-network-properties
+#     cloud_properties:
+#       lb_target_groups:
+#       - prometheus3000
+#       - prometheus9090
+#       - prometheus9093
+#       security_groups:
+#       - prometheus-lb-internal-security-group


### PR DESCRIPTION
If you want an internet-accessible prometheus in your public iaas deployment, it's likely that you'll want to attach a load balancer to the front of it using `vm_extensions`. This PR provides a small opsfile to inject one of those vm extensions to the nginx instance group, as well as some commentary on what you might do to your `cloud-config` to get that working.