### PR TITLE
Fixes issue with Grafana not showing Components Metrics v2 dashboard

### DIFF
--- a/jobs/cloudfoundry_dashboards/templates/cf_component_metrics_v2.json
+++ b/jobs/cloudfoundry_dashboards/templates/cf_component_metrics_v2.json
@@ -511,7 +511,7 @@
     ]
   },
   "timezone": "browser",
-  "title": "CF: Component Metrics",
-  "uid": "cf_component_metrics",
+  "title": "CF: Component Metrics v2",
+  "uid": "cf_component_metrics_v2",
   "version": 1
 }


### PR DESCRIPTION
This should solve the problem occurred in issue #221 .
Added 'v2' to title and uid of the Components Metrics v2 dashboard. 
Afterwards Grafana was able to load it.