### PR TITLE
Stop trying to match via regex - as this fails if the target actually contains regex chars

### DIFF
--- a/jobs/probe_dashboards/templates/probe_https_summary.json
+++ b/jobs/probe_dashboards/templates/probe_https_summary.json
@@ -130,7 +130,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "min(probe_success{instance=~\"$target\"})",
+          "expr": "min(probe_success{instance=\"$target\"})",
           "intervalFactor": 2,
           "refId": "A",
           "step": 60
@@ -222,7 +222,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "avg(probe_duration_seconds{instance=~\"$target\"})",
+          "expr": "avg(probe_duration_seconds{instance=\"$target\"})",
           "intervalFactor": 2,
           "refId": "A",
           "step": 60
@@ -304,7 +304,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "avg(probe_http_ssl{instance=~\"$target\"})",
+          "expr": "avg(probe_http_ssl{instance=\"$target\"})",
           "intervalFactor": 2,
           "refId": "A",
           "step": 60
@@ -396,7 +396,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "avg(probe_ssl_earliest_cert_expiry{instance=~\"$target\"}) - time()",
+          "expr": "avg(probe_ssl_earliest_cert_expiry{instance=\"$target\"}) - time()",
           "intervalFactor": 2,
           "refId": "A",
           "step": 60
@@ -455,7 +455,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(probe_duration_seconds{instance=~\"$target\"})",
+          "expr": "avg(probe_duration_seconds{instance=\"$target\"})",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Response Time",
@@ -538,7 +538,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(probe_http_status_code{instance=~\"$target\"})",
+          "expr": "max(probe_http_status_code{instance=\"$target\"})",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Status Code",


### PR DESCRIPTION
We were probing a URL that contained a `)`, a `$` and a `.` inside of a GET parameter.

Even when we URL encoded, by the time prometheus was done with it, we noticed the Grafana dashboard failing.

Changing the the `=~` to a `=` seemed to fix it for us.

I'm not a Grafana or Prometheus guru, but as far as I can tell, `=~` is a regex match? If so, surely nearly all the dashboards should be changed to an equality check? ie if you're selecting a target from a drop-down menu wouldn't one normally want exact matches only?

Anyway, in lieu of a bigger PR to do that, here's a little one to fix our issue.

I do worry that blindly substituting a user provided string into another string like this is inherently dangerous, but I suspect that's a bigger Grafana issue (e.g. what if `$target` contains a `"`?)