### PR TITLE
Support Postgres exporter for just custom queries

### DIFF
--- a/jobs/postgres_exporter/spec
+++ b/jobs/postgres_exporter/spec
@@ -22,3 +22,6 @@ properties:
     default: "9187"
   postgres_exporter.web.telemetry_path:
     description: "Path under which to expose Prometheus metrics"
+  postgres_exporter.disable_default_metrics:
+    description: "Disables PostgreSQL metrics and only uses custom_queries"
+    default: false

--- a/jobs/postgres_exporter/templates/bin/postgres_exporter_ctl
+++ b/jobs/postgres_exporter/templates/bin/postgres_exporter_ctl
@@ -37,6 +37,9 @@ case $1 in
       <% if_p('postgres_exporter.web.telemetry_path') do |telemetry_path| %> \
       --web.telemetry-path="<%= telemetry_path %>" \
       <% end %> \
+     <% if p('postgres_exporter.disable_default_metrics')  %> \
+      --disable-default-metrics \
+      <% end %> \
       >>  ${LOG_DIR}/postgres_exporter.stdout.log \
       2>> ${LOG_DIR}/postgres_exporter.stderr.log
     ;;


### PR DESCRIPTION
Allows the use of dedicated postgres exporters for only generating metrics based on queries