### PR TITLE
Enable proxy for Alertmanager v1.5.0

### DIFF
--- a/jobs/alertmanager/spec
+++ b/jobs/alertmanager/spec
@@ -138,6 +138,9 @@ properties:
     description: "Send a test alert weekly?"
     default: false
 
+  alertmanager.http_config.proxy_url:
+    description: "Proxy setting for Alertmanager >= v1.5.x"
+
   env.http_proxy:
     description: "HTTP proxy to use"
   env.https_proxy:

--- a/jobs/alertmanager/spec
+++ b/jobs/alertmanager/spec
@@ -138,8 +138,8 @@ properties:
     description: "Send a test alert weekly?"
     default: false
 
-  alertmanager.http_config.proxy_url:
-    description: "Proxy setting for Alertmanager >= v1.5.x"
+  alertmanager.http_config:
+    description: "Set global Alertmanager HTTP Config "
 
   env.http_proxy:
     description: "HTTP proxy to use"

--- a/jobs/alertmanager/templates/config/alertmanager.yml
+++ b/jobs/alertmanager/templates/config/alertmanager.yml
@@ -63,6 +63,11 @@ global:
   hipchat_auth_token: <%= auth_token %>
   <% end %>
 
+  <% if_p('alertmanager.http_config.proxy_url') do |proxy_url| %>
+  http_config:
+    proxy_url: <%= proxy_url %>
+  <% end %>
+
 # The directory from which notification templates are read.
 templates:
   <% p('alertmanager.templates', []).each do |template_path| %>

--- a/jobs/alertmanager/templates/config/alertmanager.yml
+++ b/jobs/alertmanager/templates/config/alertmanager.yml
@@ -63,7 +63,7 @@ global:
   hipchat_auth_token: <%= auth_token %>
   <% end %>
 
-  <% if_p('alertmanager.http_config) do |http_config| %>
+  <% if_p('alertmanager.http_config') do |http_config| %>
   http_config: <%= http_config %>
   <% end %>
 

--- a/jobs/alertmanager/templates/config/alertmanager.yml
+++ b/jobs/alertmanager/templates/config/alertmanager.yml
@@ -63,9 +63,8 @@ global:
   hipchat_auth_token: <%= auth_token %>
   <% end %>
 
-  <% if_p('alertmanager.http_config.proxy_url') do |proxy_url| %>
-  http_config:
-    proxy_url: <%= proxy_url %>
+  <% if_p('alertmanager.http_config) do |http_config| %>
+  http_config: <%= http_config %>
   <% end %>
 
 # The directory from which notification templates are read.

--- a/manifests/operators/proxy/enable-proxy-alertmanager-v1-5-0.yml
+++ b/manifests/operators/proxy/enable-proxy-alertmanager-v1-5-0.yml
@@ -1,0 +1,3 @@
+- type: replace
+  path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties?/http_config?/proxy_url
+  value: ((proxy_url))

--- a/manifests/operators/proxy/enable-proxy-alertmanager-v1-5-0.yml
+++ b/manifests/operators/proxy/enable-proxy-alertmanager-v1-5-0.yml
@@ -1,3 +1,0 @@
-- type: replace
-  path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties?/http_config?/proxy_url
-  value: ((proxy_url))

--- a/manifests/operators/proxy/enable-proxy-alertmanager.yml
+++ b/manifests/operators/proxy/enable-proxy-alertmanager.yml
@@ -1,6 +1,3 @@
 - type: replace
-  path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties?/env?
-  value:
-    http_proxy: ((http_proxy))
-    https_proxy: ((https_proxy))
-    no_proxy: ((no_proxy))
+  path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties?/http_config
+  value: ((http_config))


### PR DESCRIPTION
Fixes issue #234 .

Adds property to alertmanager spec and config template.
Adds also an ops file to enable the new proxy url.