### PR TITLE
Fix typo in lookback-delta parameter

### DIFF
--- a/jobs/prometheus2/spec
+++ b/jobs/prometheus2/spec
@@ -55,7 +55,7 @@ properties:
 
   prometheus.query.max_concurrency:
     description: "Maximum number of queries executed concurrently"
-  prometheus.query.loopback_delta:
+  prometheus.query.lookback_delta:
     description: "The delta difference allowed for retrieving metrics during expression evaluations"
   prometheus.query.timeout:
     description: "Maximum time a query may take before being aborted"

--- a/jobs/prometheus2/templates/bin/prometheus_ctl
+++ b/jobs/prometheus2/templates/bin/prometheus_ctl
@@ -50,8 +50,8 @@ case $1 in
       <% if_p('prometheus.query.max_concurrency') do |max_concurrency| %> \
       --query.max-concurrency="<%= max_concurrency %>" \
       <% end %> \
-      <% if_p('prometheus.query.loopback_delta') do |loopback_delta| %> \
-      --query.loopback-delta="<%= loopback_delta %>" \
+      <% if_p('prometheus.query.lookback_delta') do |lookback_delta| %> \
+      --query.lookback-delta="<%= lookback_delta %>" \
       <% end %> \
       <% if_p('prometheus.query.timeout') do |timeout| %> \
       --query.timeout="<%= timeout %>" \


### PR DESCRIPTION
While [migrating](https://prometheus.io/docs/prometheus/latest/migration/) from Prometheus v1 to v2, the `staleness-delta` parameter was renamed to `lookback-delta`.

This PR fixes a typo in the new name.