### PR TITLE
Remove `postgres_grafana_password` password variable

### DIFF
--- a/manifests/operators/use-sqlite3.yml
+++ b/manifests/operators/use-sqlite3.yml
@@ -9,3 +9,6 @@
   
 - type: remove
   path: /releases/name=postgres
+
+- type: remove
+  path: /variables/name=postgres_grafana_password


### PR DESCRIPTION
The `postgres_grafana_password` password variable doesn't need to exist if the database instance_group has been removed.