### PR TITLE
Fix consul_exporter alerts 

### DIFF
--- a/jobs/consul_alerts/templates/consul.alerts.yml
+++ b/jobs/consul_alerts/templates/consul.alerts.yml
@@ -12,7 +12,7 @@ groups:
           description: "The Consul instance at `{{$labels.instance}}` has been down during the last <%= p('consul_alerts.down.evaluation_time') %>"
 
       - alert: ConsulNodeHealthCheckFailing
-        expr: min(consul_health_node_status) by(instance, node, check)  < 1
+        expr: min(consul_health_node_status{status="passing"}) by(instance, node, check)  < 1
         for: <%= p('consul_alerts.node_health.evaluation_time') %>
         labels:
           service: consul


### PR DESCRIPTION
This PR fixes the alert expression of `ConsulNodeHealthCheckFailing` as described in issue #243 