### PR TITLE
Error expanding template

### DIFF
--- a/jobs/concourse_alerts/templates/concourse.alerts.yml
+++ b/jobs/concourse_alerts/templates/concourse.alerts.yml
@@ -8,5 +8,5 @@ groups:
           service: concourse
           severity: warning
         annotations:
-          summary: "Concourse worker `{{$bosh_deployment}}/{{$worker}}` is reporting too many containers"
-          description: "Concourse worker `{{$bosh_deployment}}/{{$worker}}` is reporting too many containers: {{$value}}"
+          summary: "Concourse worker `{{$labels.bosh_deployment}}/{{$labels.worker}}` is reporting too many containers"
+          description: "Concourse worker `{{$labels.bosh_deployment}}/{{$labels.worker}}` is reporting too many containers: {{$value}}"


### PR DESCRIPTION
To fix this error in AlertManager
```
<error expanding template: error parsing template __alert_ConcourseHighWorkerContainers: template: __alert_ConcourseHighWorkerContainers:1: undefined variable "$bosh_deployment">
<error expanding template: error parsing template __alert_ConcourseHighWorkerContainers: template: __alert_ConcourseHighWorkerContainers:1: undefined variable "$bosh_deployment">
```
$labels.bosh_deployment and $labels.worker are the corrects for template.