### PR TITLE
Allow more cluster configuration on alertmanager

### DIFF
--- a/jobs/alertmanager/spec
+++ b/jobs/alertmanager/spec
@@ -30,6 +30,10 @@ properties:
     description: "How long to keep data for"
   alertmanager.log_level:
     description: "Only log messages with the given severity or above. Valid levels: [debug, info, warn, error, fatal]"
+  alertmanager.cluster.listen_address:
+    description: "Cluster listen address . By default use IP computed by BOSH spec"
+  alertmanager.cluster.advertise_address:
+    description: "Cluster advertise address"
   alertmanager.cluster.gossip_interval:
     description: "Interval between sending gossip messages. By lowering this value (more frequent) gossip messages are propagated across the cluster more quickly at the expense of increased bandwidth"
   alertmanager.cluster.peer_timeout:

--- a/jobs/alertmanager/templates/bin/alertmanager_ctl
+++ b/jobs/alertmanager/templates/bin/alertmanager_ctl
@@ -45,7 +45,10 @@ case $1 in
       <% if_p('alertmanager.log_level') do |log_level| %> \
       --log.level="<%= log_level %>" \
       <% end %> \
-      --cluster.listen-address=<%= "#{spec.ip}:#{p('alertmanager.mesh.port', p('alertmanager.cluster.port'))}" %> \
+      --cluster.listen-address=<%= "#{p('alertmanager.cluster.listen_address', spec.ip)}:#{p('alertmanager.mesh.port', p('alertmanager.cluster.port'))}" %> \
+      <% if_p('alertmanager.cluster.advertise_address') do |address| %> \
+      --cluster.advertise-address="<%= "#{address}:#{p('alertmanager.mesh.port', p('alertmanager.cluster.port'))}" %>" \
+      <% end %> \
       <% if_p('alertmanager.cluster.gossip_interval') do |gossip_interval| %> \
       --cluster.gossip-interval="<%= gossip_interval %>" \
       <% end %> \


### PR DESCRIPTION
This PR adds two optional spec properties on alertmanager job:
* **cluster.listen_address**: controls `--cluster.listen-address`  (overriding default `spec.ip` if present)
* **cluster.advertise_address**: controls `--advertise-address`

These properties can be helpfull when building alertmanager clusters on [multi homed VMs](https://bosh.io/docs/networks/#multi-homed).

