### PR TITLE
Bump credhub_exporter to 0.1.5

### DIFF
--- a/packages/credhub_exporter/packaging
+++ b/packages/credhub_exporter/packaging
@@ -8,5 +8,5 @@ cp -a ${BOSH_COMPILE_TARGET}/common/* ${BOSH_INSTALL_TARGET}/common
 
 # Extract credhub_exporter package
 mkdir -p ${BOSH_INSTALL_TARGET}/bin
-tar xzvf ${BOSH_COMPILE_TARGET}/credhub_exporter/credhub_exporter-0.1.4.linux-amd64.tar.gz
-cp -a ${BOSH_COMPILE_TARGET}/credhub_exporter-0.1.4.linux-amd64/* ${BOSH_INSTALL_TARGET}/bin
+tar xzvf ${BOSH_COMPILE_TARGET}/credhub_exporter/credhub_exporter-0.1.5.linux-amd64.tar.gz
+cp -a ${BOSH_COMPILE_TARGET}/credhub_exporter-0.1.5.linux-amd64/* ${BOSH_INSTALL_TARGET}/bin

--- a/packages/credhub_exporter/spec
+++ b/packages/credhub_exporter/spec
@@ -3,5 +3,5 @@ name: credhub_exporter
 
 files:
   - common/utils.sh
-  - credhub_exporter/credhub_exporter-0.1.4.linux-amd64.tar.gz
+  - credhub_exporter/credhub_exporter-0.1.5.linux-amd64.tar.gz
 


### PR DESCRIPTION
This PR bumps [credhub_exporter](https://github.com/orange-cloudfoundry/credhub_exporter) to version [0.1.5](https://github.com/orange-cloudfoundry/credhub_exporter/releases/tag/v0.1.5) which fixes `SIGSEGV` error reported in #248 

### Blobs

* file `credhub_exporter/credhub_exporter-0.1.4.linux-amd64.tar.gz` can be removed
* file `credhub_exporter/credhub_exporter-0.1.5.linux-amd64.tar.gz` must be added. It can be downloaded  from [https://github.com/orange-cloudfoundry/credhub_exporter/releases/download/v0.1.5/credhub_exporter-0.1.5.linux-amd64.tar.gz](https://github.com/orange-cloudfoundry/credhub_exporter/releases/download/v0.1.5/credhub_exporter-0.1.5.linux-amd64.tar.gz)


Thanks:
* @amuessig for the issue
* @damzog for the fix
* and of course @frodenas for your great work :+1: 