### PR TITLE
Adjust default stemcell to use xenial instead of trusty

### DIFF
--- a/manifests/prometheus.yml
+++ b/manifests/prometheus.yml
@@ -169,7 +169,7 @@ update:
 
 stemcells:
   - alias: default
-    os: ubuntu-trusty
+    os: ubuntu-xenial
     version: latest
 
 releases:


### PR DESCRIPTION
Set ubuntu-xenial as default stemcell os type.