### PR TITLE
bump credhub_exporter to version 0.1.6

### DIFF
--- a/packages/credhub_exporter/packaging
+++ b/packages/credhub_exporter/packaging
@@ -8,5 +8,5 @@ cp -a ${BOSH_COMPILE_TARGET}/common/* ${BOSH_INSTALL_TARGET}/common
 
 # Extract credhub_exporter package
 mkdir -p ${BOSH_INSTALL_TARGET}/bin
-tar xzvf ${BOSH_COMPILE_TARGET}/credhub_exporter/credhub_exporter-0.1.5.linux-amd64.tar.gz
-cp -a ${BOSH_COMPILE_TARGET}/credhub_exporter-0.1.5.linux-amd64/* ${BOSH_INSTALL_TARGET}/bin
+tar xzvf ${BOSH_COMPILE_TARGET}/credhub_exporter/credhub_exporter-0.1.6.linux-amd64.tar.gz
+cp -a ${BOSH_COMPILE_TARGET}/credhub_exporter-0.1.6.linux-amd64/* ${BOSH_INSTALL_TARGET}/bin

--- a/packages/credhub_exporter/spec
+++ b/packages/credhub_exporter/spec
@@ -3,5 +3,5 @@ name: credhub_exporter
 
 files:
   - common/utils.sh
-  - credhub_exporter/credhub_exporter-0.1.5.linux-amd64.tar.gz
+  - credhub_exporter/credhub_exporter-0.1.6.linux-amd64.tar.gz
 


### PR DESCRIPTION
This PR bumps [credhub_exporter](https://github.com/orange-cloudfoundry/credhub_exporter) to version [0.1.6](https://github.com/orange-cloudfoundry/credhub_exporter/releases/tag/v0.1.6) which another program crash

### Blobs

* file `credhub_exporter/credhub_exporter-0.1.5.linux-amd64.tar.gz` can be **removed**
* file `credhub_exporter/credhub_exporter-0.1.6.linux-amd64.tar.gz` must be **added**. It can be downloaded  from [https://github.com/orange-cloudfoundry/credhub_exporter/releases/download/v0.1.6/credhub_exporter-0.1.6.linux-amd64.tar.gz](https://github.com/orange-cloudfoundry/credhub_exporter/releases/download/v0.1.6/credhub_exporter-0.1.6.linux-amd64.tar.gz)


Thanks:
* @jtuchscherer  for the fix
