### PR TITLE
Add Generic OAuth2 Operator for Grafana

### DIFF
--- a/manifests/operators/enable-grafana-generic-oauth.yml
+++ b/manifests/operators/enable-grafana-generic-oauth.yml
@@ -1,0 +1,19 @@
+---
+- type: replace
+  path: /instance_groups/name=grafana/jobs/name=grafana/properties/grafana/auth?/generic_oauth
+  value:
+    enabled: true
+    allow_sign_up: true
+    allowed_domains: "((grafana_oauth_allowed_domains))"
+    api_url: "((grafana_oauth_api_url))"
+    auth_url: "((grafana_oauth_auth_url))"
+    client_id: "((grafana_oauth_client_id))"
+    client_secret: "((grafana_oauth_client_secret))"
+    name: "((grafana_oauth_name))"
+    scopes: "((grafana_oauth_scopes))"
+    team_ids: "((grafana_oauth_team_ids))"
+    tls_client_ca: "((grafana_oauth_tls_client_ca))"
+    tls_client_cert: "((grafana_oauth_tls_client_cert))"
+    tls_client_key: "((grafana_oauth_tls_client_key))"
+    tls_skip_verify_insecure: ((grafana_oauth_tls_skip_verify_insecure))
+    token_url: "((grafana_oauth_token_url))"

--- a/manifests/operators/enable-root-url.yml
+++ b/manifests/operators/enable-root-url.yml
@@ -1,0 +1,4 @@
+---
+- type: replace
+  path: /instance_groups/name=grafana/jobs/name=grafana/properties/grafana/server?/root_url
+  value: "((grafana_root_url))"


### PR DESCRIPTION
TL;DR:
=====
- Add operator for `generic_oauth` (non-biased OAuth2 configuration)
- Add operator for `root_url` (requisite for OAuth2 redirect)

Detail:
======
These operators allow a deployment to have a generic OAuth2 provider
added as an authentication mechanism for Grafana. This includes all
values that are presented in the [spec](https://github.com/bosh-prometheus/prometheus-boshrelease/blob/master/jobs/grafana/spec#L267-L296).

All variables are configurable, with the exception of the following:
- `grafana.auth.generic_oauth.enabled`
- `grafana.auth.generic_oauth.allow_sign_up`

The `enabled` attribute is our intended purpose of adding this
operator, so that will always be set to `true`. The `allow_sign_up`
attribute provides the ability to allow or deny the creation of users
in Grafana that are provided by the OAuth2 provider. This is detailed
further, [here](http://docs.grafana.org/installation/configuration/#allow-sign-up).
Without this enabled, users will not be able to login.

A generic OAuth2 operator was provided for UAA in
328da574783de6abb078763abffca50a6a978d83, but this is heavily biased
towards using UAA, specifically. For using alternate backends (in my
case, ADFS), a generic operator is required. Additionally, this did
not present the option to rewrite `root_url`.

If opting to use the `enable-grafana-generic-oauth` operator, the
`root_url` may need to be modified to match what the OAuth2 provider
is expecting (in many production use-cases), and also necessary to
make the redirect (call-back) _from_ the OAuth2 provider to the client
functional. The `enable-root-url` operator is intended for this
use-case. Further reading is available, [here](http://docs.grafana.org/installation/configuration/#root-url).

NOTE:
====
These operators were separated to enable the `enable-root-url`
operator to be used without any OAuth2-specific configuration (useful
for proxying scenarios).