### PR TITLE
Enable monitor CF Isolation Segment on CF/Apps dashboard

### DIFF
--- a/jobs/cloudfoundry_dashboards/templates/cf_apps_latency.json
+++ b/jobs/cloudfoundry_dashboards/templates/cf_apps_latency.json
@@ -104,7 +104,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_http_start_stop_client_request_duration_seconds_sum{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"} / firehose_http_start_stop_client_request_duration_seconds_count{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"})",
+          "expr": "avg(firehose_http_start_stop_client_request_duration_seconds_sum{environment=~\"$environment\",application_id=~\"$cf_application_id\"} / firehose_http_start_stop_client_request_duration_seconds_count{environment=~\"$environment\",application_id=~\"$cf_application_id\"})",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Client",
@@ -112,7 +112,7 @@
           "step": 2
         },
         {
-          "expr": "avg(firehose_http_start_stop_server_request_duration_seconds_sum{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"} / firehose_http_start_stop_server_request_duration_seconds_count{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"})",
+          "expr": "avg(firehose_http_start_stop_server_request_duration_seconds_sum{environment=~\"$environment\",application_id=~\"$cf_application_id\"} / firehose_http_start_stop_server_request_duration_seconds_count{environment=~\"$environment\",application_id=~\"$cf_application_id\"})",
           "intervalFactor": 2,
           "legendFormat": "Server",
           "refId": "B",
@@ -200,7 +200,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_http_start_stop_client_request_duration_seconds{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}) by(quantile)",
+          "expr": "avg(firehose_http_start_stop_client_request_duration_seconds{environment=~\"$environment\",application_id=~\"$cf_application_id\"}) by(quantile)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ quantile }}",
@@ -289,7 +289,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_http_start_stop_server_request_duration_seconds{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}) by(quantile)",
+          "expr": "avg(firehose_http_start_stop_server_request_duration_seconds{environment=~\"$environment\",application_id=~\"$cf_application_id\"}) by(quantile)",
           "intervalFactor": 2,
           "legendFormat": "{{ quantile }}",
           "refId": "A",

--- a/jobs/cloudfoundry_dashboards/templates/cf_apps_requests.json
+++ b/jobs/cloudfoundry_dashboards/templates/cf_apps_requests.json
@@ -103,7 +103,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}[5m]))",
+          "expr": "avg(rate(firehose_http_start_stop_requests{environment=~\"$environment\",application_id=~\"$cf_application_id\"}[5m]))",
           "intervalFactor": 2,
           "legendFormat": "Requests",
           "refId": "A",
@@ -189,7 +189,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"})",
+          "expr": "sum(firehose_http_start_stop_requests{environment=~\"$environment\",application_id=~\"$cf_application_id\"})",
           "intervalFactor": 2,
           "legendFormat": "Requests",
           "refId": "A",
@@ -272,7 +272,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}[5m])) by(instance_id)",
+          "expr": "avg(rate(firehose_http_start_stop_requests{environment=~\"$environment\",application_id=~\"$cf_application_id\"}[5m])) by(instance_id)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ instance_id }}",
@@ -355,7 +355,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}) by(instance_id)",
+          "expr": "sum(firehose_http_start_stop_requests{environment=~\"$environment\",application_id=~\"$cf_application_id\"}) by(instance_id)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ instance_id }}",
@@ -441,7 +441,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}[5m])) by(method)",
+          "expr": "avg(rate(firehose_http_start_stop_requests{environment=~\"$environment\",application_id=~\"$cf_application_id\"}[5m])) by(method)",
           "intervalFactor": 2,
           "legendFormat": "{{ method }}",
           "refId": "A",
@@ -526,7 +526,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}) by(method)",
+          "expr": "sum(firehose_http_start_stop_requests{environment=~\"$environment\",application_id=~\"$cf_application_id\"}) by(method)",
           "intervalFactor": 2,
           "legendFormat": "{{ method }}",
           "refId": "A",
@@ -611,7 +611,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}[5m])) by(status_code)",
+          "expr": "avg(rate(firehose_http_start_stop_requests{environment=~\"$environment\",application_id=~\"$cf_application_id\"}[5m])) by(status_code)",
           "intervalFactor": 2,
           "legendFormat": "{{ status_code }}",
           "refId": "A",
@@ -696,7 +696,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}) by(status_code)",
+          "expr": "sum(firehose_http_start_stop_requests{environment=~\"$environment\",application_id=~\"$cf_application_id\"}) by(status_code)",
           "intervalFactor": 2,
           "legendFormat": "{{ status_code }}",
           "refId": "A",
@@ -781,7 +781,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}[5m])) by(scheme)",
+          "expr": "avg(rate(firehose_http_start_stop_requests{environment=~\"$environment\",application_id=~\"$cf_application_id\"}[5m])) by(scheme)",
           "intervalFactor": 2,
           "legendFormat": "{{ scheme }}",
           "refId": "A",
@@ -866,7 +866,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}) by(scheme)",
+          "expr": "sum(firehose_http_start_stop_requests{environment=~\"$environment\",application_id=~\"$cf_application_id\"}) by(scheme)",
           "intervalFactor": 2,
           "legendFormat": "{{ scheme }}",
           "refId": "A",
@@ -951,7 +951,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}[5m])) by(host)",
+          "expr": "avg(rate(firehose_http_start_stop_requests{environment=~\"$environment\",application_id=~\"$cf_application_id\"}[5m])) by(host)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ host }}",
@@ -1037,7 +1037,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}) by(host)",
+          "expr": "sum(firehose_http_start_stop_requests{environment=~\"$environment\",application_id=~\"$cf_application_id\"}) by(host)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ host }}",
@@ -1122,7 +1122,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_http_start_stop_response_size_bytes_sum{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"} / firehose_http_start_stop_response_size_bytes_count{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"})",
+          "expr": "avg(firehose_http_start_stop_response_size_bytes_sum{environment=~\"$environment\",application_id=~\"$cf_application_id\"} / firehose_http_start_stop_response_size_bytes_count{environment=~\"$environment\",application_id=~\"$cf_application_id\"})",
           "intervalFactor": 2,
           "legendFormat": "Size",
           "refId": "A",
@@ -1206,7 +1206,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_http_start_stop_response_size_bytes{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}) by(quantile)",
+          "expr": "avg(firehose_http_start_stop_response_size_bytes{environment=~\"$environment\",application_id=~\"$cf_application_id\"}) by(quantile)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ quantile }}",

--- a/jobs/cloudfoundry_dashboards/templates/cf_apps_system.json
+++ b/jobs/cloudfoundry_dashboards/templates/cf_apps_system.json
@@ -197,7 +197,7 @@
       ],
       "targets": [
         {
-          "expr": "count(firehose_container_metric_cpu_percentage{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}) by(instance_index,  bosh_job_ip)",
+          "expr": "count(firehose_container_metric_cpu_percentage{environment=~\"$environment\",application_id=~\"$cf_application_id\"}) by(instance_index,  bosh_job_ip)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -347,7 +347,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_container_metric_cpu_percentage{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"})",
+          "expr": "avg(firehose_container_metric_cpu_percentage{environment=~\"$environment\",application_id=~\"$cf_application_id\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -432,7 +432,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_container_metric_cpu_percentage{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}) by(instance_index) ",
+          "expr": "avg(firehose_container_metric_cpu_percentage{environment=~\"$environment\",application_id=~\"$cf_application_id\"}) by(instance_index) ",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -529,7 +529,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_container_metric_memory_bytes{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"})",
+          "expr": "avg(firehose_container_metric_memory_bytes{environment=~\"$environment\",application_id=~\"$cf_application_id\"})",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Used",
@@ -537,7 +537,7 @@
           "step": 10
         },
         {
-          "expr": "avg(firehose_container_metric_memory_bytes_quota{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"})",
+          "expr": "avg(firehose_container_metric_memory_bytes_quota{environment=~\"$environment\",application_id=~\"$cf_application_id\"})",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Quota",
@@ -621,7 +621,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_container_metric_memory_bytes{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}) by(instance_index) ",
+          "expr": "avg(firehose_container_metric_memory_bytes{environment=~\"$environment\",application_id=~\"$cf_application_id\"}) by(instance_index) ",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{ instance_index }}",
@@ -629,7 +629,7 @@
           "step": 10
         },
         {
-          "expr": "avg(firehose_container_metric_memory_bytes_quota{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"})",
+          "expr": "avg(firehose_container_metric_memory_bytes_quota{environment=~\"$environment\",application_id=~\"$cf_application_id\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -726,7 +726,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_container_metric_disk_bytes{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"})",
+          "expr": "avg(firehose_container_metric_disk_bytes{environment=~\"$environment\",application_id=~\"$cf_application_id\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -735,7 +735,7 @@
           "step": 10
         },
         {
-          "expr": "avg(firehose_container_metric_disk_bytes_quota{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"})",
+          "expr": "avg(firehose_container_metric_disk_bytes_quota{environment=~\"$environment\",application_id=~\"$cf_application_id\"})",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -820,7 +820,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_container_metric_disk_bytes{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}) by(instance_index) ",
+          "expr": "avg(firehose_container_metric_disk_bytes{environment=~\"$environment\",application_id=~\"$cf_application_id\"}) by(instance_index) ",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ instance_index }}",
@@ -828,7 +828,7 @@
           "step": 10
         },
         {
-          "expr": "avg(firehose_container_metric_disk_bytes_quota{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"})",
+          "expr": "avg(firehose_container_metric_disk_bytes_quota{environment=~\"$environment\",application_id=~\"$cf_application_id\"})",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Quota",


### PR DESCRIPTION
Update Grafana dashboards `Cloudfoundry`/`Apps: System`, `Apps: Requests`, `Apps: Latency` for using CF Isolation Segment.

Please review, merge and release new version.

## Example Changes
Before:
```
avg(firehose_container_metric_cpu_percentage{environment=~"$environment",bosh_deployment=~"$bosh_deployment",application_id=~"$cf_application_id"})
```

After:
```
avg(firehose_container_metric_cpu_percentage{environment=~"$environment", application_id=~"$cf_application_id"})
```

## Why Change
Metrics for variable templating `cf_application_info`'s `deployment` is different from `firehose_container_metric_cpu_percentage`'s `bosh_deployment` on CF Isolation Segment. (Similarly other metrics)

If CF Isolation Segment using, monitoring metrics `firehose_container_metric_cpu_percentage` has different `bosh_deployment` on CF basic's.

Since `application_id` is unique key, `bosh_deployment` filter key is unneeded.

## Example Metrics
- CF basic (deployment="cf",bosh_deployment="cf")
```
cf_application_info{application_id="36852824-xxxx-xxxx-xxxx-xxxxxxxxxxxx",application_name="app",buildpack="java_buildpack_offline",deployment="cf",environment="p-bosh",instance="localhost:9193",job="cf_exporter",organization_id="f2c75a5b-xxxx-xxxx-xxxx-xxxxxxxxxxxx",organization_name="org",space_id="f3be9cb8-xxxx-xxxx-xxxx-xxxxxxxxxxxx",space_name="staging",stack_id="e1d11f77-xxxx-xxxx-xxxx-xxxxxxxxxxxx",state="STARTED"}
firehose_container_metric_cpu_percentage{application_id="36852824-xxxx-xxxx-xxxx-xxxxxxxxxxxx",bosh_deployment="cf",bosh_job_id="38b0b513-xxxx-xxxx-xxxx-xxxxxxxxxxxx",bosh_job_ip="172.26.x.x",bosh_job_name="diego_cell",environment="p-bosh",instance="localhost:9186",instance_index="0",job="firehose_exporter",origin="rep"}	
```

- CF Isolation Segment (deployment="cf",bosh_deployment="p-isolation-segment-xxx)(in case of Pivotal-CF)
```
cf_application_info{application_id="4bfa9c7c-xxxx-xxxx-xxxx-xxxxxxxxxxxx",application_name="app",buildpack="java_buildpack_offline",deployment="cf",environment="p-bosh",instance="localhost:9193",job="cf_exporter",organization_id="f2c75a5b-xxxx-xxxx-xxxx-xxxxxxxxxxxx",organization_name="org",space_id="cfee18fa-xxxx-xxxx-xxxx-xxxxxxxxxxxx",space_name="develop",stack_id="e1d11f77-xxxx-xxxx-xxxx-xxxxxxxxxxxx",state="STARTED"}	
firehose_container_metric_cpu_percentage{application_id="4bfa9c7c-xxxx-xxxx-xxxx-xxxxxxxxxxxx",bosh_deployment="p-isolation-segment-5af2xxxxxxxxxxxxxxxx",bosh_job_id="7a06a28c-xxxx-xxxx-xxxx-xxxxxxxxxxxx",bosh_job_ip="172.26.x.x",bosh_job_name="isolated_diego_cell",environment="p-bosh",instance="localhost:9186",instance_index="0",job="firehose_exporter",origin="rep"}
```
