### PR TITLE
Add option to nginx job to disable cross zone load balancing

### DIFF
--- a/jobs/nginx/spec
+++ b/jobs/nginx/spec
@@ -106,6 +106,9 @@ properties:
   nginx.alertmanager.headers:
     description: "Arbitrary headers to set on alertmanager server"
     default: {}
+  nginx.alertmanager.cross_zone_load_balancing:
+    description: "If disabled, this will only route traffic to instances in the same availability zone"
+    default: true
 
   nginx.grafana.server_name:
     description: "Server name that proxy will listen on for Grafana HTTP(S) connections"
@@ -129,6 +132,9 @@ properties:
   nginx.grafana.headers:
     description: "Arbitrary headers to set on grafana server"
     default: {}
+  nginx.grafana.cross_zone_load_balancing:
+    description: "If disabled, this will only route traffic to instances in the same availability zone"
+    default: true
 
   nginx.prometheus.server_name:
     description: "Server name that proxy will listen on for Prometheus HTTP(S) connections"
@@ -152,3 +158,6 @@ properties:
   nginx.prometheus.headers:
     description: "Arbitrary headers to set on prometheus server"
     default: {}
+  nginx.prometheus.cross_zone_load_balancing:
+    description: "If disabled, this will only route traffic to instances in the same availability zone"
+    default: true

--- a/jobs/nginx/templates/config/nginx.conf
+++ b/jobs/nginx/templates/config/nginx.conf
@@ -59,7 +59,9 @@ http {
   <% if_link('alertmanager') do |alertmanager| %>
   upstream alertmanager {
     <% alertmanager.instances.map do |instance| %>
-    server <%= "#{instance.address}:#{alertmanager.p('alertmanager.web.port')} fail_timeout=0;" %>
+      <% if p('nginx.alertmanager.cross_zone_load_balancing') || instance.az == spec.az %>
+      server <%= "#{instance.address}:#{alertmanager.p('alertmanager.web.port')} fail_timeout=0;" %>
+      <% end %>
     <% end %>
   }
 
@@ -109,7 +111,9 @@ http {
   <% if_link('grafana') do |grafana| %>
   upstream grafana {
     <% grafana.instances.map do |instance| %>
-    server <%= "#{instance.address}:#{grafana.p('grafana.server.http_port')} fail_timeout=0;" %>
+      <% if p('nginx.grafana.cross_zone_load_balancing') || instance.az == spec.az %>
+      server <%= "#{instance.address}:#{grafana.p('grafana.server.http_port')} fail_timeout=0;" %>
+      <% end %>
     <% end %>
   }
 
@@ -159,7 +163,9 @@ http {
   <% if_link('prometheus') do |prometheus| %>
   upstream prometheus {
     <% prometheus.instances.map do |instance| %>
-    server <%= "#{instance.address}:#{prometheus.p('prometheus.web.port')} fail_timeout=0;" %>
+      <% if p('nginx.prometheus.cross_zone_load_balancing') || instance.az == spec.az %>
+      server <%= "#{instance.address}:#{prometheus.p('prometheus.web.port')} fail_timeout=0;" %>
+      <% end %>
     <% end %>
   }
 


### PR DESCRIPTION
## What

Currently the nginx job will add all Prometheus, Alertmanager and Grafana instances to the upstream configurations. We want to be able to tell nginx that it should only forward requests to instances in the same availability zone.

This PR adds three extra parameters (`*.cross_zone_load_balancing`) with a default true, so it's possible to disable cross-zone load balancing.

## Why

We are deploying Prometheus in an HA setup, so we have two independent clusters in two availability zones. We want to disable any cross-zone load balancing so we always know which servers are we communicating with.