### PR TITLE
Add service_discovery job to generate service discovery files using BOSH links

### DIFF
--- a/jobs/firehose_exporter/spec
+++ b/jobs/firehose_exporter/spec
@@ -9,6 +9,10 @@ templates:
   config/web_tls_cert.pem: config/web_tls_cert.pem
   config/web_tls_key.pem: config/web_tls_key.pem
 
+provides:
+  - name: firehose_exporter
+    type: firehose_exporter
+
 properties:
   firehose_exporter.uaa.url:
     description: "Cloud Foundry UAA URL"

--- a/jobs/service_discovery/spec
+++ b/jobs/service_discovery/spec
@@ -1,0 +1,26 @@
+---
+
+name: service_discovery
+
+packages: []
+
+templates:
+  firehose_exporter_target_groups.json.erb: firehose_exporter_target_groups.json
+  grafana_target_groups.json.erb: grafana_target_groups.json
+  prometheus_target_groups.json.erb: prometheus_target_groups.json
+
+consumes:
+  - name: firehose_exporter
+    type: firehose_exporter
+    optional: true
+  - name: grafana
+    type: grafana
+    optional: true
+  - name: prometheus
+    type: prometheus
+    optional: true
+
+properties:
+  service_discovery.az_affinity:
+    description: "If true then only instances from the same availability zone will be included in the generated JSON files"
+    default: true

--- a/jobs/service_discovery/templates/firehose_exporter_target_groups.json.erb
+++ b/jobs/service_discovery/templates/firehose_exporter_target_groups.json.erb
@@ -1,0 +1,23 @@
+<%=
+
+instances = []
+
+if_link("firehose_exporter") do |link|
+  instances = link.instances
+end
+
+if p("service_discovery.az_affinity")
+  instances = instances.select{ |inst| inst.az == spec.az }
+end
+
+result = {
+  "targets" => instances.map { |inst| inst.address },
+  "labels" => {
+    "__meta_bosh_deployment" => spec.deployment,
+    "__meta_bosh_job_process_name" => "firehose_exporter"
+  }
+}
+
+JSON.dump([result])
+
+%>

--- a/jobs/service_discovery/templates/grafana_target_groups.json.erb
+++ b/jobs/service_discovery/templates/grafana_target_groups.json.erb
@@ -1,0 +1,23 @@
+<%=
+
+instances = []
+
+if_link("grafana") do |link|
+  instances = link.instances
+end
+
+if p("service_discovery.az_affinity")
+  instances = instances.select{ |inst| inst.az == spec.az }
+end
+
+result = {
+  "targets" => instances.map { |inst| inst.address },
+  "labels" => {
+    "__meta_bosh_deployment" => spec.deployment,
+    "__meta_bosh_job_process_name" => "grafana"
+  }
+}
+
+JSON.dump([result])
+
+%>

--- a/jobs/service_discovery/templates/prometheus_target_groups.json.erb
+++ b/jobs/service_discovery/templates/prometheus_target_groups.json.erb
@@ -1,0 +1,23 @@
+<%=
+
+instances = []
+
+if_link("prometheus") do |link|
+  instances = link.instances
+end
+
+if p("service_discovery.az_affinity")
+  instances = instances.select{ |inst| inst.az == spec.az }
+end
+
+result = {
+  "targets" => instances.map { |inst| inst.address },
+  "labels" => {
+    "__meta_bosh_deployment" => spec.deployment,
+    "__meta_bosh_job_process_name" => "prometheus2"
+  }
+}
+
+JSON.dump([result])
+
+%>

--- a/manifests/operators/enable-service-discovery.yml
+++ b/manifests/operators/enable-service-discovery.yml
@@ -1,0 +1,6 @@
+- type: replace
+  path: /instance_groups/name=prometheus2/jobs/-
+  value:
+    name: service_discovery
+    release: prometheus
+    properties: {}


### PR DESCRIPTION
## What

This PR adds a new optional job called `service_discovery` which can be used to generate service discovery files (used by `file_sd_configs`) for some jobs.

Compared to the bosh-exporter this job uses BOSH links to generate service discovery files for Prometheus2, Grafana and the Firehose-exporter.

By using the `az_affinity` parameter you can control whether you want to include instances from the same availability zone only.

## Why

We are deploying Prometheus in an HA setup, so we have two independent clusters in two availability zones. There is currently no way to tell the Prometheus instances that they should scrape the Prometheus metrics, the Grafana metrics and the Firehose metrics from the same AZ only.

The biggest issue for us was the firehose-exporter, as all metrics were duplicated in both Prometheus instances which we wanted to avoid.

Also this might have some limited usefulness for some people who don't want to use the bosh-exporter's service discovery file.