### PR TITLE
Allow to set a unique subscription id for the firehose-exporter

### DIFF
--- a/jobs/firehose_exporter/spec
+++ b/jobs/firehose_exporter/spec
@@ -20,6 +20,10 @@ properties:
     description: "Cloud Foundry Doppler URL"
   firehose_exporter.doppler.subscription_id:
     description: "Cloud Foundry Doppler Subscription ID"
+    default: prometheus
+  firehose_exporter.doppler.use_unique_subscription_id:
+    description: "If true the instance id will be added as a suffix to the subscription id"
+    default: false
   firehose_exporter.doppler.idle_timeout:
     description: "Cloud Foundry Doppler Idle Timeout"
   firehose_exporter.doppler.min_retry_delay:

--- a/jobs/firehose_exporter/templates/bin/firehose_exporter_ctl
+++ b/jobs/firehose_exporter/templates/bin/firehose_exporter_ctl
@@ -39,8 +39,10 @@ case $1 in
       --uaa.client-id="<%= p('firehose_exporter.uaa.client_id') %>" \
       --uaa.client-secret="<%= p('firehose_exporter.uaa.client_secret') %>" \
       --doppler.url="<%= p('firehose_exporter.doppler.url') %>" \
-      <% if_p('firehose_exporter.doppler.subscription_id') do |subscription_id| %> \
-      --doppler.subscription-id="<%= subscription_id %>" \
+      <% if p('firehose_exporter.doppler.use_unique_subscription_id') %> \
+      --doppler.subscription-id="<%= "#{p('firehose_exporter.doppler.subscription_id')}-#{spec.id}" %>" \
+      <% else %> \
+      --doppler.subscription-id="<%= p('firehose_exporter.doppler.subscription_id') %>" \
       <% end %> \
       <% if_p('firehose_exporter.doppler.idle_timeout') do |idle_timeout| %> \
       --doppler.idle-timeout="<%= idle_timeout %>" \


### PR DESCRIPTION
## What

Allow to set a unique subscription id for the firehose-exporter

This PR adds a new parameter called `firehose_exporter.doppler.use_unique_subscription_id`. If it's true then the BOSH VM id will be added as a suffix to the subscription id.

The default value of `firehose_exporter.doppler.subscription_id` will be set to `prometheus` as if this is not set the firehose-exporter will still use that as a default value. This makes it clearer to use it together with the `use_unique_subscription_id` flag.
