### PR TITLE
Correct the y-axes for the Metron Egress in the CF: Metron Agent dashboard from bytes to short

### DIFF
--- a/jobs/cloudfoundry_dashboards/templates/cf_metron_agent_v2.json
+++ b/jobs/cloudfoundry_dashboards/templates/cf_metron_agent_v2.json
@@ -142,7 +142,7 @@
       },
       "yaxes": [
         {
-          "format": "bytes",
+          "format": "short",
           "label": null,
           "logBase": 1,
           "max": null,


### PR DESCRIPTION
Just a small quality of life thing.
The graph for Metron Egress is displaying in bytes, when it looks like it should be just a number of messages.

Swapped the format from bytes to short so it is displayed as a number of messages.

Old: 
![image](https://user-images.githubusercontent.com/17762025/53104441-a76a3000-352f-11e9-80a7-c2ac738ccce6.png)

New: 
![image](https://user-images.githubusercontent.com/17762025/53104556-da142880-352f-11e9-9e19-5beeeba56585.png)
