### PR TITLE
Switch from storage.tsdb.retention property to storage.tsdb.retention.time

### DIFF
--- a/jobs/prometheus2/spec
+++ b/jobs/prometheus2/spec
@@ -69,7 +69,7 @@ properties:
   prometheus.rules.alert.resend_delay:
     description: "Minimum amount of time to wait before resending an alert to Alertmanager"
 
-  prometheus.storage.tsdb.retention:
+  prometheus.storage.tsdb.retention.time:
     description: "How long to retain samples in the storage"
   prometheus.storage.tsdb.min_block_duration:
     description: "Minimum duration of a data block before being persisted"

--- a/jobs/prometheus2/templates/bin/prometheus_ctl
+++ b/jobs/prometheus2/templates/bin/prometheus_ctl
@@ -69,8 +69,8 @@ case $1 in
       --rules.alert.resend-delay="<%= resend_delayt %>" \
       <% end %> \
       --storage.tsdb.path="${STORE_DIR}" \
-      <% if_p('prometheus.storage.tsdb.retention') do |retention| %> \
-      --storage.tsdb.retention="<%= retention %>" \
+      <% if_p('prometheus.storage.tsdb.retention.time') do |retention| %> \
+      --storage.tsdb.retention.time="<%= retention %>" \
       <% end %> \
       <% if_p('prometheus.storage.tsdb.min_block_duration') do |min_block_duration| %> \
       --storage.tsdb.min-block-duration="<%= min_block_duration %>" \


### PR DESCRIPTION
This PR will substitute the deprecated `storage.tsdb.retention`property to `storage.tsdb.retention.time` as mentioned in #296 .

I decided to go with the `.time` instead of `_time` to be more flexible to add `storage.tsdb.retention.size` to spec as soon as it leaves status experimental. 