### PR TITLE
Support Concourse 5.0

### DIFF
--- a/manifests/operators/concourse/enable-prometheus-metrics.yml
+++ b/manifests/operators/concourse/enable-prometheus-metrics.yml
@@ -2,7 +2,7 @@
 
 # Enable prometheus metrics
 - type: replace
-  path: /instance_groups/name=web/jobs/name=atc/properties/prometheus?
+  path: /instance_groups/name=web/jobs/name=web/properties/prometheus?
   value:
     bind_ip: 0.0.0.0
     bind_port: 9391

--- a/manifests/operators/monitor-bosh.yml
+++ b/manifests/operators/monitor-bosh.yml
@@ -188,7 +188,7 @@
     relabel_configs:
       - source_labels:
         - __meta_bosh_job_process_name
-        regex: atc
+        regex: web
         action: keep
       - source_labels:
         - __meta_bosh_deployment


### PR DESCRIPTION
Job name for `atc` has been renamed to `web` in concourse 5.0.