### PR TITLE
Create alertmanager-group-by-alertname.yml

### DIFF
--- a/manifests/operators/alertmanager-group-by-alertname.yml
+++ b/manifests/operators/alertmanager-group-by-alertname.yml
@@ -1,0 +1,13 @@
+- type: replace
+  path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties/alertmanager/route/group_by?
+  value:
+  - alertname
+- type: replace
+  path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties/alertmanager/route/group_wait?
+  value: 30s
+- type: replace
+  path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties/alertmanager/route/group_interval?
+  value: 5m
+- type: replace
+  path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties/alertmanager/route/repeat_interval?
+  value: 4h


### PR DESCRIPTION
This commit enables grouping alerts by name.

https://prometheus.io/docs/alerting/configuration/#example

Without this configuration, alerts will be summarized when multiple type alerts happen at the same time.

Please take a took at `[Firing:N]` (`N` > 1)  in the following image: 

![image](https://user-images.githubusercontent.com/106908/56261967-e07de580-6117-11e9-86f8-ff506492a75a.png)
