### PR TITLE
Consume remote_write connection through a BOSH link

### DIFF
--- a/jobs/prometheus2/spec
+++ b/jobs/prometheus2/spec
@@ -8,6 +8,7 @@ templates:
   bin/prometheus_ctl: bin/prometheus_ctl
   config/prometheus.yml: config/prometheus.yml
   config/custom.rules.yml: config/custom.rules.yml
+  config/remote_write_ca.crt: config/remote_write_ca.crt
 
 provides:
   - name: prometheus

--- a/jobs/prometheus2/spec
+++ b/jobs/prometheus2/spec
@@ -23,6 +23,9 @@ consumes:
   - name: prometheus-remote-read
     type: prometheus-remote-read
     optional: true
+  - name: prometheus-remote-write
+    type: prometheus-remote-write
+    optional: true
 
 properties:
   prometheus.log_level:

--- a/jobs/prometheus2/templates/config/prometheus.yml
+++ b/jobs/prometheus2/templates/config/prometheus.yml
@@ -44,7 +44,12 @@ remote_read:
 remote_read: <%= p('prometheus.remote_read', []).to_json %>
 <% end %>
 
-<% if_p('prometheus.remote_write') do |remote_write| %>
 # Settings related to the experimental remote write feature.
-remote_write: <%= remote_write.to_json %>
+<% if_link('prometheus-remote-write') do |prometheus_remote_write| %>
+remote_write:
+  <% prometheus_remote_write.instances.each do |instance| %>
+  - url: http://<%= instance.address %>:<%= prometheus_remote_write.p('web.port') %>/api/v1/write
+  <% end %>
+<% end.else do %>
+remote_write: <%= p('prometheus.remote_write', []).to_json %>
 <% end %>

--- a/jobs/prometheus2/templates/config/remote_write_ca.crt
+++ b/jobs/prometheus2/templates/config/remote_write_ca.crt
@@ -1,0 +1,3 @@
+<% if_link('prometheus-remote-write') do |prometheus_remote_write| %>
+<%= prometheus_remote_write.p('tls.ca', '') %>
+<% end %>


### PR DESCRIPTION
1. Add a BOSH link support for remote_write configuration.
1. Allow to consume CA cert for remote_write, useful when remote_write storage configured with HTTPS.