### PR TITLE
Allow setting resolver for nginx

### DIFF
--- a/jobs/nginx/spec
+++ b/jobs/nginx/spec
@@ -83,6 +83,11 @@ properties:
   nginx.proxy_send_timeout:
     description: "Timeout for send queries to the upstream server"
     default: 120
+  nginx.resolver.address:
+    description: "DNS Resolver for Nginx"
+  nginx.resolver.enable_ipv6:
+    description: "Enable IPv6 lookups (only applies when using nginx.resolver.address)
+    default: false
 
   nginx.alertmanager.server_name:
     description: "Server name that proxy will listen on for Alertmanager HTTP(S) connections"

--- a/jobs/nginx/templates/config/nginx.conf
+++ b/jobs/nginx/templates/config/nginx.conf
@@ -56,6 +56,10 @@ http {
   gzip_buffers        16 8k;
   gzip_disable        "MSIE [1-6]\.(?!.*SV1)";
 
+  <% if_p('nginx.resolver.address') do |resolver| %>
+  resolver <%= resolver %> <% unless p('nginx.resolver.enable_ipv6') %> ipv6=off <% end %>;
+  <% end %>
+
   <% if_link('alertmanager') do |alertmanager| %>
   upstream alertmanager {
     <% alertmanager.instances.map do |instance| %>


### PR DESCRIPTION
Allow setting custom resolver for nginx, and allow toggling IPv6 resolution for that resolver.

Motivation:
Nginx only resolves hostnames once at startup if you don't declare a resolver. This causes issues when one or more of the upstreams nginx is targeting gets a new IP address.