### PR TITLE
Use YAML style config for graphite_exporter

### DIFF
--- a/jobs/graphite_exporter/spec
+++ b/jobs/graphite_exporter/spec
@@ -6,7 +6,7 @@ packages:
 
 templates:
   bin/graphite_exporter_ctl: bin/graphite_exporter_ctl
-  config/graphite_mapping.conf: config/graphite_mapping.conf
+  config/graphite_mapping.yml: config/graphite_mapping.yml
 
 properties:
   graphite_exporter.graphite.port:

--- a/jobs/graphite_exporter/templates/bin/graphite_exporter_ctl
+++ b/jobs/graphite_exporter/templates/bin/graphite_exporter_ctl
@@ -24,7 +24,7 @@ case $1 in
     exec graphite_exporter \
       --graphite.listen-address=":<%= p('graphite_exporter.graphite.port') %>" \
       <% if_p('graphite_exporter.graphite.mapping_config') do %> \
-      --graphite.mapping-config="/var/vcap/jobs/graphite_exporter/config/graphite_mapping.conf" \
+      --graphite.mapping-config="/var/vcap/jobs/graphite_exporter/config/graphite_mapping.yml" \
       <% end %> \
       <% if_p('graphite_exporter.graphite.mapping_strict_match') do |mapping_strict_match| %> \
       --graphite.mapping-strict-match="<%= mapping_strict_match %>" \

--- a/jobs/graphite_exporter/templates/config/graphite_mapping.conf
+++ b/jobs/graphite_exporter/templates/config/graphite_mapping.conf
@@ -1,1 +1,0 @@
-<%= p('graphite_exporter.graphite.mapping_config', '') %>

--- a/jobs/graphite_exporter/templates/config/graphite_mapping.yml
+++ b/jobs/graphite_exporter/templates/config/graphite_mapping.yml
@@ -1,0 +1,1 @@
+mappings: <%= p('graphite_exporter.graphite.mapping_config', []).to_json %>


### PR DESCRIPTION
Since v0.3.0 graphite_exporter is configured to use YAML style config for metrics mapping configuration.

https://github.com/prometheus/graphite_exporter/releases/tag/v0.3.0