### PR TITLE
graphite-exporter: changing the variable mapping-strict-match

### DIFF
--- a/jobs/graphite_exporter/templates/bin/graphite_exporter_ctl
+++ b/jobs/graphite_exporter/templates/bin/graphite_exporter_ctl
@@ -26,8 +26,8 @@ case $1 in
       <% if_p('graphite_exporter.graphite.mapping_config') do %> \
       --graphite.mapping-config="/var/vcap/jobs/graphite_exporter/config/graphite_mapping.conf" \
       <% end %> \
-      <% if_p('graphite_exporter.graphite.mapping_strict_match') do |mapping_strict_match| %> \
-      --graphite.mapping-strict-match="<%= mapping_strict_match %>" \
+      <% if_p('graphite_exporter.graphite.mapping_strict_match') do %> \
+      --graphite.mapping-strict-match \
       <% end %> \
       <% if_p('graphite_exporter.graphite.sample_expiry') do |sample_expiry| %> \
       --graphite.sample-expiry="<%= sample_expiry %>" \


### PR DESCRIPTION
In the newest versions for graphite-exporter the option --graphite.mapping-strict-match doesn't accept any passing value, due to this, it is necessary to update the logic in the job's template due to is failing at the moment is being used.
