### PR TITLE
Allow setting server_names_hash_bucket_size for Nginx

### DIFF
--- a/jobs/nginx/spec
+++ b/jobs/nginx/spec
@@ -88,6 +88,8 @@ properties:
   nginx.resolver.enable_ipv6:
     description: "Enable IPv6 lookups (only applies when using nginx.resolver.address)
     default: false
+  nginx.server_names_hash_bucket_size:
+    description: "The bucket size for the server names hash tables"
 
   nginx.alertmanager.server_name:
     description: "Server name that proxy will listen on for Alertmanager HTTP(S) connections"

--- a/jobs/nginx/templates/config/nginx.conf
+++ b/jobs/nginx/templates/config/nginx.conf
@@ -60,6 +60,10 @@ http {
   resolver <%= resolver %> <% unless p('nginx.resolver.enable_ipv6') %> ipv6=off <% end %>;
   <% end %>
 
+  <% if_p('nginx.server_names_hash_bucket_size') do |size| %>
+  server_names_hash_bucket_size <%= size %>;
+  <% end %>
+
   <% if_link('alertmanager') do |alertmanager| %>
   upstream alertmanager {
     <% alertmanager.instances.map do |instance| %>


### PR DESCRIPTION
We have pretty long domain names and Nginx is failing to start with the following error:
```
2019/07/12 12:45:13 [emerg] 30360#0: could not build server_names_hash, you should increase server_names_hash_bucket_size: 64
```

This PR allows to increase `server_names_hash_bucket_size ` config property for Nginx.