### PR TITLE
Drop duplicate prefix from cookie_samesite

### DIFF
--- a/jobs/grafana/spec
+++ b/jobs/grafana/spec
@@ -174,7 +174,7 @@ properties:
     description: "disable protection against brute force login attempts"
   grafana.security.cookie_secure:
     description: "Set to true if you host Grafana behind HTTPS"
-  grafana.security.grafana.security.cookie_samesite:
+  grafana.security.cookie_samesite:
     description: "Set cookie SameSite attribute (lax, strict and none)"
 
   grafana.snapshots.external_enabled:


### PR DESCRIPTION
`grafana.security`, `grafana.security` so good they named it twice.

It's actually just `grafana.security.cookie_samesite` in [the template](https://github.com/bosh-prometheus/prometheus-boshrelease/blob/e96d2f275e635b5d3c49a6905dc5a6a7f2be03cb/jobs/grafana/templates/config/grafana.ini#L324-L327)