### PR TITLE
Concourse dashboard fixes & refinements

### DIFF
--- a/jobs/concourse_dashboards/templates/concourse_overview.json
+++ b/jobs/concourse_dashboards/templates/concourse_overview.json
@@ -51,8 +51,8 @@
   "editable": false,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": null,
-  "iteration": 1523194747923,
+  "id": 134,
+  "iteration": 1567787951317,
   "links": [
     {
       "asDropdown": true,
@@ -623,6 +623,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Builds Started / Finished",
       "tooltip": {
@@ -656,7 +657,11 @@
           "min": null,
           "show": false
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -709,6 +714,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "HTTP Response Duration",
       "tooltip": {
@@ -742,7 +748,100 @@
           "min": null,
           "show": false
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "description": "Peaks correlates to active builds.\n\nObserving some leaks",
+      "fill": 1,
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "id": 17,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "max(  #over the concourse node reporting counters\n  concourse_builds_started_total{bosh_deployment=~\"$bosh_deployment\"} \n  - concourse_builds_finished_total{bosh_deployment=~\"$bosh_deployment\"}\n) \n\nby(bosh_deployment)",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "intervalFactor": 2,
+          "legendFormat": "Pending",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Started - Finished Builds",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": true,
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -756,7 +855,7 @@
         "h": 5,
         "w": 12,
         "x": 0,
-        "y": 9
+        "y": 14
       },
       "id": 1,
       "legend": {
@@ -793,6 +892,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Worker Containers",
       "tooltip": {
@@ -826,7 +926,11 @@
           "min": null,
           "show": false
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -876,6 +980,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Worker Volumes",
       "tooltip": {
@@ -909,7 +1014,11 @@
           "min": null,
           "show": false
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -923,7 +1032,7 @@
         "h": 5,
         "w": 12,
         "x": 0,
-        "y": 14
+        "y": 19
       },
       "id": 3,
       "legend": {
@@ -962,6 +1071,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Database Connections",
       "tooltip": {
@@ -995,7 +1105,11 @@
           "min": null,
           "show": false
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -1035,16 +1149,25 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(concourse_db_queries_total{bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment)",
+          "expr": "#Concourse 3\nmax(concourse_db_queries{bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Queries",
           "refId": "A",
           "step": 120
+        },
+        {
+          "expr": "#Concourse 5\nmax(concourse_db_queries_total{bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment)",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Queries",
+          "refId": "B",
+          "step": 120
         }
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Database Queries",
       "tooltip": {
@@ -1078,11 +1201,303 @@
           "min": null,
           "show": false
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "description": "Database locks held, averaged in 10 mins buckets",
+      "fill": 1,
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 12,
+        "y": 19
+      },
+      "id": 15,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(concourse_locks_held{bosh_deployment=~\"$bosh_deployment\"}) by (type)\n",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Database locks held",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": "checks per mins",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "cacheTimeout": null,
+      "dashLength": 10,
+      "dashes": false,
+      "description": "Graph shows top 10 Finished jobs averaged in 10 mins buckets.\n\nTable shows total jobs builds counter since prom restart.",
+      "fill": 1,
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      },
+      "id": 19,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": false,
+        "hideEmpty": true,
+        "hideZero": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sort": "total",
+        "sortDesc": true,
+        "total": true,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "topk(10, # keep only top 10 to avoid eating up memory\n  max ( #over the web nodes maintaining counters\n    increase(\n        concourse_builds_finished{bosh_deployment=~\"$bosh_deployment\",status=\"succeeded\"}[1h]\n      )\n  )\n  by (exported_job) \n)\n",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "intervalFactor": 1,
+          "legendFormat": "{{exported_job}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [
+        {
+          "colorMode": "critical",
+          "fill": true,
+          "line": true,
+          "op": "gt",
+          "yaxis": "left"
+        }
+      ],
+      "timeFrom": null,
+      "timeRegions": [
+        {
+          "colorMode": "background6",
+          "fill": true,
+          "fillColor": "rgba(234, 112, 112, 0.12)",
+          "line": false,
+          "lineColor": "rgba(237, 46, 24, 0.60)",
+          "op": "time"
+        }
+      ],
+      "timeShift": null,
+      "title": "top 10 job builds ",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": "per hours",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "cacheTimeout": null,
+      "columns": [
+        {
+          "text": "Max",
+          "value": "max"
+        }
+      ],
+      "description": "Full count of all successful jobs executions since last concourse restart",
+      "fontSize": "100%",
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 30
+      },
+      "id": 21,
+      "links": [],
+      "pageSize": null,
+      "scroll": true,
+      "showHeader": true,
+      "sort": {
+        "col": 3,
+        "desc": true
+      },
+      "styles": [
+        {
+          "alias": "",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "",
+          "thresholds": [],
+          "type": "number",
+          "unit": "short"
+        },
+        {
+          "alias": "",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "decimals": 0,
+          "pattern": "Max",
+          "thresholds": [],
+          "type": "number",
+          "unit": "short"
+        },
+        {
+          "alias": "",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "Time",
+          "thresholds": [],
+          "type": "hidden",
+          "unit": "short"
+        }
+      ],
+      "targets": [
+        {
+          "expr": "sum(concourse_builds_finished{bosh_deployment=~\"$bosh_deployment\",status=\"succeeded\"}) by (pipeline, exported_job)\n",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "intervalFactor": 1,
+          "legendFormat": "{{pipeline}}/{{exported_job}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Successful jobs count",
+      "transform": "table",
+      "type": "table"
     }
+
   ],
   "refresh": "30s",
-  "schemaVersion": 16,
+  "schemaVersion": 18,
   "style": "dark",
   "tags": [
     "concourse"
@@ -1143,5 +1558,5 @@
   "timezone": "browser",
   "title": "Concourse: Overview",
   "uid": "concourse_overview",
-  "version": 1
+  "version": 2
 }

--- a/jobs/concourse_dashboards/templates/concourse_overview.json
+++ b/jobs/concourse_dashboards/templates/concourse_overview.json
@@ -1035,7 +1035,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(concourse_db_queries{bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment)",
+          "expr": "max(concourse_db_queries_total{bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Queries",

--- a/jobs/concourse_dashboards/templates/concourse_pipelines.json
+++ b/jobs/concourse_dashboards/templates/concourse_pipelines.json
@@ -45,8 +45,7 @@
   "editable": false,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": null,
-  "iteration": 1523181477375,
+  "iteration": 1567579109551,
   "links": [
     {
       "asDropdown": true,
@@ -108,15 +107,24 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(concourse_scheduling_full_duration_seconds{bosh_deployment=~\"$bosh_deployment\", pipeline=~\"$pipeline\"}) by(bosh_deployment, pipeline)",
+          "expr": "#Valid until concourse 4.2.1\nmax(concourse_scheduling_full_duration_seconds{bosh_deployment=~\"$bosh_deployment\", pipeline=~\"$pipeline\"}) by(bosh_deployment, pipeline)",
           "format": "time_series",
+          "hide": false,
           "intervalFactor": 2,
           "legendFormat": "Duration",
           "refId": "A"
+        },
+        {
+          "expr": "#Valid starting concourse 4.2.2 and 5.x\nmax(concourse_scheduling_full_duration_seconds_total{bosh_deployment=~\"$bosh_deployment\", pipeline=~\"$pipeline\"}) by(bosh_deployment, pipeline)",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Duration",
+          "refId": "B"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Scheduling: Full",
       "tooltip": {
@@ -150,7 +158,11 @@
           "min": null,
           "show": false
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -190,15 +202,23 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(concourse_scheduling_loading_duration_seconds{bosh_deployment=~\"$bosh_deployment\", pipeline=~\"$pipeline\"}) by(bosh_deployment, pipeline)",
+          "expr": "#Valid until concourse 4.2.1\nmax(concourse_scheduling_loading_duration_seconds{bosh_deployment=~\"$bosh_deployment\", pipeline=~\"$pipeline\"}) by(bosh_deployment, pipeline)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Duration",
           "refId": "A"
+        },
+        {
+          "expr": "#Valid starting concourse 4.2.2 and 5.x\nmax(concourse_scheduling_loading_duration_seconds_total{bosh_deployment=~\"$bosh_deployment\", pipeline=~\"$pipeline\"}) by(bosh_deployment, pipeline)",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Duration",
+          "refId": "B"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Scheduling: Loading",
       "tooltip": {
@@ -232,7 +252,11 @@
           "min": null,
           "show": false
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -240,7 +264,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "${DS_PROMETHEUS}",
-      "description": "Last time taken to calculate the set of valid input versions for a pipeline",
+      "description": "Last time taken to calculate the set of valid input versions for a pipeline. Not present anymore in concourse 5.x",
       "fill": 1,
       "gridPos": {
         "h": 5,
@@ -272,7 +296,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(concourse_scheduling_job_duration_seconds{bosh_deployment=~\"$bosh_deployment\", pipeline=~\"$pipeline\"}) by(bosh_deployment, pipeline)",
+          "expr": "#Valid until concourse 4.2.1\nmax(concourse_scheduling_job_duration_seconds{bosh_deployment=~\"$bosh_deployment\", pipeline=~\"$pipeline\"}) by(bosh_deployment, pipeline)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Duration",
@@ -281,6 +305,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Scheduling: Job",
       "tooltip": {
@@ -314,7 +339,11 @@
           "min": null,
           "show": false
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -365,6 +394,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Builds Finished",
       "tooltip": {
@@ -399,7 +429,11 @@
           "min": null,
           "show": false
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -441,7 +475,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(concourse_builds_duration_seconds_sum{bosh_deployment=~\"$bosh_deployment\", pipeline=~\"$pipeline\"}[5m]) / rate(concourse_builds_duration_seconds_count{bosh_deployment=~\"$bosh_deployment\", pipeline=~\"$pipeline\"}[5m])) by(bosh_deployment, pipeline)",
+          "expr": "avg(\n  rate(concourse_builds_duration_seconds_sum{bosh_deployment=~\"$bosh_deployment\", pipeline=~\"$pipeline\"}[5m]) / \n  rate(concourse_builds_duration_seconds_count{bosh_deployment=~\"$bosh_deployment\", pipeline=~\"$pipeline\"}[5m])\n) by(bosh_deployment, pipeline)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Duration",
@@ -450,6 +484,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Build Duration",
       "tooltip": {
@@ -483,11 +518,15 @@
           "min": null,
           "show": false
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     }
   ],
   "refresh": "30s",
-  "schemaVersion": 16,
+  "schemaVersion": 18,
   "style": "dark",
   "tags": [
     "concourse"
@@ -496,8 +535,12 @@
     "list": [
       {
         "allValue": null,
-        "current": {},
+        "current": {
+          "text": "concourse",
+          "value": "concourse"
+        },
         "datasource": "${DS_PROMETHEUS}",
+        "definition": "",
         "hide": 0,
         "includeAll": false,
         "label": "Deployment",
@@ -507,6 +550,7 @@
         "query": "label_values(concourse_builds_finished, bosh_deployment)",
         "refresh": 1,
         "regex": "",
+        "skipUrlSync": false,
         "sort": 1,
         "tagValuesQuery": "",
         "tags": [],
@@ -516,8 +560,13 @@
       },
       {
         "allValue": null,
-        "current": {},
+        "current": {
+          "tags": [],
+          "text": "control-plane",
+          "value": "control-plane"
+        },
         "datasource": "${DS_PROMETHEUS}",
+        "definition": "",
         "hide": 0,
         "includeAll": false,
         "label": "Pipeline",
@@ -527,6 +576,7 @@
         "query": "label_values(concourse_builds_finished{bosh_deployment=~\"$bosh_deployment\"}, pipeline)",
         "refresh": 1,
         "regex": "",
+        "skipUrlSync": false,
         "sort": 1,
         "tagValuesQuery": "",
         "tags": [],


### PR DESCRIPTION
 Fixes to concourse dashboard with concourse 5
- some metrics converted to counters in concourse/concourse@838161c
- job scheduling metric removed in concourse/concourse@f3ca6b3

New panels in concourse overview:
- Started - Finished Builds
- Database locks held
- Top 10 job builds
- Table of all successful jobs executions since last concourse restart

On my integration server, this looks like
![image](https://user-images.githubusercontent.com/4748380/64509571-514cb680-d2e0-11e9-8fd0-1620c66fde67.png)

@frodenas @jmcarp
I'm still new to prometheus, so dashboard might require fine tuning for syntax changes that I might have overlooked

There are a few over panels that might be useful, possibly in a new dashboard, which I did not include yet in this PR:
- history of build failures
- resource checks per pipeline
![image](https://user-images.githubusercontent.com/4748380/64509790-c7e9b400-d2e0-11e9-96d5-30f5b1fc5693.png)
![image](https://user-images.githubusercontent.com/4748380/64509871-fa93ac80-d2e0-11e9-8057-bbc5b874df31.png)

In the future, I'd like to find a way to add more concourse internal metrics to match concourse team dashboas content exposed at https://metrics.concourse-ci.org/d/000000007/concourse?orgId=1&refresh=1m 
- atc goroutines, 
-node exporter metrics (pointer to native bosh dashboards)

However, there is on going draft refactoring in the concourse 5 exporter at https://github.com/concourse/concourse/pull/4247 which might be worth waiting before investing too much.

Also, it might be worth refactor existing dashboards in 3 parts, matching use-cases and actos
- for concourse operators: concouse state (atc, worker, database, API response time) (a subset of of `concourse_overview` dashboard)
- for concourse users:
   - overview of pipeline and jobs: most expensive pipeline/jobs, error rates ... (new dashboard)
   - detail on single pipeline (existing `concourse_pipelines`)
