### PR TITLE
Updating org and space dashboards with the following changes:

### DIFF
--- a/jobs/cloudfoundry_dashboards/templates/cf_organization_memory_quotas.json
+++ b/jobs/cloudfoundry_dashboards/templates/cf_organization_memory_quotas.json
@@ -113,7 +113,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "((sum(avg(cf_application_memory_mb{environment=~\"$environment\",deployment=~\"$bosh_deployment\"}) by(organization_name, application_id) * on (organization_name, application_id) count(cf_application_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\",state=\"STARTED\"}) by(organization_name, application_id)) by(organization_name) / on(organization_name) avg(cf_organization_total_memory_mb_quota{environment=~\"$environment\",deployment=~\"$bosh_deployment\"}) by(organization_name) > 0) * 100 > $quota_limit) * on (organization_name) group_left(quota_name) count(cf_organization_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\",quota_name=~\"$cf_quota_name\"}) by(organization_name, quota_name)",
+          "expr": "((sum(avg(cf_application_memory_mb{environment=~\"$environment\",deployment=~\"$bosh_deployment\"} * on (organization_name, application_id) cf_application_instances{environment=~\"$environment\",deployment=~\"$bosh_deployment\",state=\"STARTED\"}) by(organization_name, application_id)) by(organization_name) / on(organization_name) avg(cf_organization_total_memory_mb_quota{environment=~\"$environment\",deployment=~\"$bosh_deployment\"}) by(organization_name) > 0) * 100 > $quota_limit) * on (organization_name) group_left(quota_name) count(cf_organization_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\",quota_name=~\"$cf_quota_name\"}) by(organization_name, quota_name)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ organization_name }} ({{ quota_name }})",
@@ -199,7 +199,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(cf_application_memory_mb{environment=~\"$environment\",deployment=~\"$bosh_deployment\"}) by(organization_name, application_id)) by(organization_name) * on (organization_name)  group_left(quota_name) count(cf_organization_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\",quota_name=~\"$cf_quota_name\"}) by(organization_name, quota_name)",
+          "expr": "sum(avg(cf_application_memory_mb{environment=~\"$environment\",deployment=~\"$bosh_deployment\"} * on (organization_name, application_id) cf_application_instances{environment=~\"$environment\",deployment=~\"$bosh_deployment\",state=\"STARTED\"}) by(organization_name, application_id)) by(organization_name) * on (organization_name) group_left(quota_name) count(cf_organization_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\",quota_name=~\"$cf_quota_name\"}) by(organization_name, quota_name)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ organization_name }} ({{ quota_name }})",
@@ -228,7 +228,7 @@
       },
       "yaxes": [
         {
-          "format": "decmbytes",
+          "format": "mbytes",
           "label": null,
           "logBase": 1,
           "max": null,

--- a/jobs/cloudfoundry_dashboards/templates/cf_organization_summary.json
+++ b/jobs/cloudfoundry_dashboards/templates/cf_organization_summary.json
@@ -83,7 +83,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "${DS_PROMETHEUS}",
-      "description": "Total number of Instances and Quota for this Organization.",
+      "description": "Total number of running Instances and Quota for this Organization.",
       "fill": 1,
       "gridPos": {
         "h": 5,
@@ -115,7 +115,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(cf_application_instances{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_name=~\"$cf_organization_name\"}) by(application_id))",
+          "expr": "sum(avg(cf_application_instances{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_name=~\"$cf_organization_name\",state=\"STARTED\"}) by(application_id))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Used",
@@ -220,7 +220,7 @@
       "dashes": false,
       "datasource": "${DS_PROMETHEUS}",
       "decimals": null,
-      "description": "Total Memory Used and Quota for this Organization.",
+      "description": "Total Memory Used by running instances and Quota for this Organization.",
       "fill": 1,
       "gridPos": {
         "h": 5,
@@ -252,7 +252,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(cf_application_memory_mb{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_name=~\"$cf_organization_name\"}) by(application_id))",
+          "expr": "sum(avg(cf_application_memory_mb{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_name=~\"$cf_organization_name\"} * on (application_id) cf_application_instances{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_name=~\"$cf_organization_name\",state=\"STARTED\"}) by(application_id))",
           "intervalFactor": 2,
           "legendFormat": "Used",
           "refId": "A",
@@ -311,7 +311,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "${DS_PROMETHEUS}",
-      "description": "Total Disk allocated and Quota for this Organization.",
+      "description": "Total Disk allocated to running instances for this Organization.",
       "fill": 1,
       "gridPos": {
         "h": 5,
@@ -343,17 +343,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(cf_application_disk_quota_mb{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_name=~\"$cf_organization_name\"}) by(application_id))",
+          "expr": "sum(avg(cf_application_disk_quota_mb{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_name=~\"$cf_organization_name\"} * on (application_id) cf_application_instances{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_name=~\"$cf_organization_name\",state=\"STARTED\"}) by(application_id))",
           "intervalFactor": 2,
           "legendFormat": "Used",
           "refId": "A",
-          "step": 4
-        },
-        {
-          "expr": "avg(cf_organization_total_memory_mb_quota{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_name=~\"$cf_organization_name\"})",
-          "intervalFactor": 2,
-          "legendFormat": "Quota",
-          "refId": "B",
           "step": 4
         }
       ],

--- a/jobs/cloudfoundry_dashboards/templates/cf_space_summary.json
+++ b/jobs/cloudfoundry_dashboards/templates/cf_space_summary.json
@@ -83,7 +83,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "${DS_PROMETHEUS}",
-      "description": "Total number of Instances and Quota for this Space.",
+      "description": "Total number of running Instances and Quota for this Space.",
       "fill": 1,
       "gridPos": {
         "h": 5,
@@ -115,7 +115,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(cf_application_instances{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_id=~\"$cf_organization_id\",space_name=~\"$cf_space_name\"}) by(application_id))",
+          "expr": "sum(avg(cf_application_instances{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_id=~\"$cf_organization_id\",space_name=~\"$cf_space_name\",state=\"STARTED\"}) by(application_id))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Used",
@@ -220,7 +220,7 @@
       "dashes": false,
       "datasource": "${DS_PROMETHEUS}",
       "decimals": null,
-      "description": "Total Memory Used and Quota for this Space.",
+      "description": "Total Memory Used by running instances and Quota for this Space.",
       "fill": 1,
       "gridPos": {
         "h": 5,
@@ -252,7 +252,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(cf_application_memory_mb{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_id=~\"$cf_organization_id\",space_name=~\"$cf_space_name\"}) by(application_id))",
+          "expr": "sum(avg(cf_application_memory_mb{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_id=~\"$cf_organization_id\",space_name=~\"$cf_space_name\"} * on (application_id) cf_application_instances{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_id=~\"$cf_organization_id\",space_name=~\"$cf_space_name\",state=\"STARTED\"}) by(application_id))",
           "intervalFactor": 2,
           "legendFormat": "Used",
           "refId": "A",
@@ -311,7 +311,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "${DS_PROMETHEUS}",
-      "description": "Total Disk allocated and Quota for this Space.",
+      "description": "Total Disk allocated to running instances for this Space.",
       "fill": 1,
       "gridPos": {
         "h": 5,
@@ -343,17 +343,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(cf_application_disk_quota_mb{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_id=~\"$cf_organization_id\",space_name=~\"$cf_space_name\"}) by(application_id))",
+          "expr": "sum(avg(cf_application_disk_quota_mb{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_id=~\"$cf_organization_id\",space_name=~\"$cf_space_name\"} * on (application_id) cf_application_instances{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_id=~\"$cf_organization_id\",space_name=~\"$cf_space_name\",state=\"STARTED\"}) by(application_id))",
           "intervalFactor": 2,
           "legendFormat": "Used",
           "refId": "A",
-          "step": 4
-        },
-        {
-          "expr": "avg(cf_space_total_memory_mb_quota{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_id=~\"$cf_organization_id\",space_name=~\"$cf_space_name\"})",
-          "intervalFactor": 2,
-          "legendFormat": "Quota",
-          "refId": "B",
           "step": 4
         }
       ],


### PR DESCRIPTION
* cf_organization_memory_quotas.json: Updating graphs to multiply memory usage by the number of instances and fix the data type to standard instead of decimal megabytes

* cf_organization_summary.json: Updating graphs to only show running instances to correspond with how CF implements quota, updating descriptions, removing extraneous memory quota line on the disk usage chart, and multiply memory and disk usage by the number of instances.

* cf_space_summary.json: Updating graphs to only show running instances to correspond with how CF implements quota, updating descriptio
ns, removing extraneous memory quota line on the disk usage chart, and multiply memory and disk usage by the number of instances.