### PR TITLE
Fix the Credhub link properties for credhub_exporter

### DIFF
--- a/jobs/credhub_exporter/templates/bin/credhub_exporter_ctl
+++ b/jobs/credhub_exporter/templates/bin/credhub_exporter_ctl
@@ -38,8 +38,8 @@ case $1 in
        url = ""
        ca_certs = ""
        if_link("credhub") do |link|
-         url      = sprintf("https://%s:%d", link.p('internal_url'), link.p('port'))
-         ca_certs = link.p('ca_certificate')
+         url      = sprintf("https://%s:%d", link.p('credhub.internal_url'), link.p('credhub.port'))
+         ca_certs = link.p('credhub.ca_certificate')
        end.else do
          url      = p("credhub_exporter.credhub.api_url")
          ca_certs = p("credhub_exporter.credhub.ca_certs", "")

--- a/jobs/credhub_exporter/templates/config/credhub_tls_ca_cert.pem
+++ b/jobs/credhub_exporter/templates/config/credhub_tls_ca_cert.pem
@@ -1,5 +1,5 @@
 <% if_link("credhub") do |link| %>
-<%= link.p('ca_certificate') %>
+<%= link.p('credhub.ca_certificate') %>
 <% end.else do %>
 <%= p("credhub_exporter.credhub.ca_certs", "") %>
 <% end %>


### PR DESCRIPTION
Hi,

This PR fixes the names of properties that are accessed through the `credhub` BOSH link.

Indeed, those properties are prefixed with `credhub.`, as shown [here in the `credhub` job spec](https://github.com/pivotal-cf/credhub-release/blob/master/jobs/credhub/spec#L60-L62).

Best,
Benjamin