### PR TITLE
Add Grafana Statusmap panel plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "src/grafana_plugins/Grafana_Status_panel"]
 	path = src/grafana_plugins/Grafana_Status_panel
 	url = https://github.com/Vonage/Grafana_Status_panel.git
+[submodule "src/grafana_plugins/flant-statusmap-panel"]
+	path = src/grafana_plugins/flant-statusmap-panel
+	url = https://github.com/flant/grafana-statusmap


### PR DESCRIPTION
https://grafana.com/grafana/plugins/flant-statusmap-panel

Used in a new RabbitMQ Grafana dashboard, yet to be uploaded to
grafana.com: https://grafana.gcp.rabbitmq.com/d/d-SFCCmZz/erlang-distribution?orgId=1