### PR TITLE
Add missing backslashes in prometheus_ctl

### DIFF
--- a/jobs/prometheus2/templates/bin/prometheus_ctl
+++ b/jobs/prometheus2/templates/bin/prometheus_ctl
@@ -86,10 +86,10 @@ case $1 in
       <% end %> \
       <% if p('prometheus.storage.tsdb.no_lockfile') %> \
       --storage.tsdb.no-lockfile \
-      <% end %>
+      <% end %> \
       <% if p('prometheus.storage.tsdb.wal_compression') %> \
       --storage.tsdb.wal-compression \
-      <% end %>
+      <% end %> \
       <% if_p('prometheus.storage.remote.flush_deadline') do |flush_deadline| %> \
       --storage.remote.flush-deadline="<%= flush_deadline %>" \
       <% end %> \


### PR DESCRIPTION
After the upgrade to v26.0.0 I noticed that `web.external-url` flag shows empty string in Prometheus Command-Line Flags page. In my environment all command line flags after the `storage.tsdb.no-lockfile` flag are not initialized during the start. 
This also affects Alertmanager integration with Prometheus.