### PR TITLE
Convert exporter credentials to envvars 

### DIFF
--- a/jobs/bosh_exporter/templates/bin/bosh_exporter_ctl
+++ b/jobs/bosh_exporter/templates/bin/bosh_exporter_ctl
@@ -34,19 +34,23 @@ case $1 in
     export no_proxy="<%= no_proxy %>"
     <% end %>
 
+    <% if_p('bosh_exporter.bosh.password') do |password| %>
+    export BOSH_EXPORTER_BOSH_PASSWORD="<%= password %>"
+    <% end %>
+    <% if_p('bosh_exporter.bosh.uaa.client_secret') do |client_secret| %>
+    export BOSH_EXPORTER_BOSH_UAA_CLIENT_SECRET="<%= client_secret %>"
+    <% end %>
+    <% if_p('bosh_exporter.web.auth_password') do |auth_password| %>
+    export BOSH_EXPORTER_WEB_AUTH_PASSWORD="<%= auth_password %>"
+    <% end %>
+
     exec bosh_exporter \
       --bosh.url="<%= p('bosh_exporter.bosh.url') %>" \
       <% if_p('bosh_exporter.bosh.username') do |username| %> \
       --bosh.username="<%= username %>" \
       <% end %> \
-      <% if_p('bosh_exporter.bosh.password') do |password| %> \
-      --bosh.password="<%= password %>" \
-      <% end %> \
       <% if_p('bosh_exporter.bosh.uaa.client_id') do |client_id| %> \
       --bosh.uaa.client-id="<%= client_id %>" \
-      <% end %> \
-      <% if_p('bosh_exporter.bosh.uaa.client_secret') do |client_secret| %> \
-      --bosh.uaa.client-secret="<%= client_secret %>" \
       <% end %> \
       <% if_p('bosh_exporter.bosh.log_level') do |log_level| %> \
       --bosh.log-level="<%= log_level %>" \
@@ -86,9 +90,6 @@ case $1 in
       <% end %> \
       <% if_p('bosh_exporter.web.auth_username') do |auth_username| %> \
       --web.auth.username="<%= auth_username %>" \
-      <% end %> \
-      <% if_p('bosh_exporter.web.auth_password') do |auth_password| %> \
-      --web.auth.password="<%= auth_password %>" \
       <% end %> \
       <% if_p('bosh_exporter.web.tls_cert', 'bosh_exporter.web.tls_key') do %> \
       --web.tls.cert_file="/var/vcap/jobs/bosh_exporter/config/web_tls_cert.pem" \

--- a/jobs/firehose_exporter/templates/bin/firehose_exporter_ctl
+++ b/jobs/firehose_exporter/templates/bin/firehose_exporter_ctl
@@ -34,10 +34,14 @@ case $1 in
     export no_proxy="<%= no_proxy %>"
     <% end %>
 
+    export FIREHOSE_EXPORTER_UAA_CLIENT_SECRET="<%= p('firehose_exporter.uaa.client_secret') %>"
+    <% if_p('firehose_exporter.web.auth_password') do |auth_password| %>
+    export FIREHOSE_EXPORTER_WEB_AUTH_PASSWORD="<%= auth_password %>"
+    <% end %>
+
     exec firehose_exporter \
       --uaa.url="<%= p('firehose_exporter.uaa.url') %>" \
       --uaa.client-id="<%= p('firehose_exporter.uaa.client_id') %>" \
-      --uaa.client-secret="<%= p('firehose_exporter.uaa.client_secret') %>" \
       <% if p('firehose_exporter.doppler.use_unique_subscription_id') %> \
       --doppler.subscription-id="<%= "#{p('firehose_exporter.doppler.subscription_id')}-#{spec.id}" %>" \
       <% else %> \
@@ -90,9 +94,6 @@ case $1 in
       <% end %> \
       <% if_p('firehose_exporter.web.auth_username') do |auth_username| %> \
       --web.auth.username="<%= auth_username %>" \
-      <% end %> \
-      <% if_p('firehose_exporter.web.auth_password') do |auth_password| %> \
-      --web.auth.password="<%= auth_password %>" \
       <% end %> \
       <% if_p('firehose_exporter.web.tls_cert', 'firehosef_exporter.web.tls_key') do %> \
       --web.tls.cert_file="/var/vcap/jobs/firehose_exporter/config/web_tls_cert.pem" \


### PR DESCRIPTION
Continuation of https://github.com/bosh-prometheus/prometheus-boshrelease/pull/354

@frodenas let me know if you'd like me to update the rest of these exporters; I can do it in a single PR which touches many of these. Or only this PR which update the ones _I_ personally actively use at first? etc. Apologies, just checking before I drop a PR with multiple touchpoints.

- [x] [bosh_exporter](https://github.com/bosh-prometheus/bosh_exporter#flags)
- [ ] [bosh_tsdb_exporter](https://github.com/bosh-prometheus/bosh_tsdb_exporter#flags)
- [ ] [collectd_exporter](https://github.com/prometheus/collectd_exporter)
- [ ] [consul_exporter](https://github.com/prometheus/consul_exporter#environment-variables)
- [ ] credhub_exporter
- [ ] elasticsearch_exporter
- [x] [firehose_exporter](https://github.com/bosh-prometheus/firehose_exporter#flags)
- [ ] graphite_exporter
- [ ] haproxy_exporter
- [ ] influxdb_exporter
- [ ] kube-state-metrics exporter 
- [ ] memchacjed exporter
- [ ] mongodb_exporter
- [ ] mysqld_exporter
- [ ] nats_exporter
- [ ] postgres_exporter
- [ ] rabbitmq_exporter
- [ ] redis_exporter
- [ ] [shield_experort](https://github.com/bosh-prometheus/shield_exporter#flags)
- [ ] stackdriver+exporter
- [ ] statsd_exporter
- [ ] vault_exporter

