### PR TITLE
Fix bug in grafana admin password reset script

### DIFF
--- a/jobs/grafana/templates/bin/grafana-admin-password
+++ b/jobs/grafana/templates/bin/grafana-admin-password
@@ -18,9 +18,10 @@ if [[ i -gt $retries ]]; then
   exit 1
 fi
 
-/var/vcap/packages/grafana/bin/grafana-cli admin reset-admin-password \
+/var/vcap/packages/grafana/bin/grafana-cli \
   --homepath=/var/vcap/packages/grafana \
   --config=/var/vcap/jobs/grafana/config/grafana.ini \
+  admin reset-admin-password \
   <%= p("grafana.security.admin_password") %>
 
 exit 0


### PR DESCRIPTION
Grafana CLI global options _must_ come before command and command options. Currently we are seeing the following error in `less /var/vcap/sys/log/grafana/post-start.stdout.log`:

```
[Wed Nov 20 14:30:12 UTC 2019] Resetting grafana admin password ...
Waiting for grafana to listen on port 3000 (0/60)
Grafana is ready
Incorrect Usage: flag provided but not defined: -homepath

NAME:
   Grafana cli admin reset-admin-password - reset-admin-password <new password>

USAGE:
   Grafana cli admin reset-admin-password [arguments...]
```

This is because the `grafana-admin-password` script was passing the `-homepath` and `-config` global options _after_ the `admin reset-admin-password` command, which is not supported. I have verified this fix works by manually updating `/var/vcap/jobs/grafana/bin/grafana-admin-password` to fix the argument ordering on a running prometheus deployment and verifying that the script no longer fails.

I assume that the argument ordering requirement was introduced into the grafana CLI at some point after this script was made.