### PR TITLE
Allow to provision additional Grafana datasources

### DIFF
--- a/jobs/grafana/spec
+++ b/jobs/grafana/spec
@@ -18,6 +18,7 @@ templates:
   config/provisioning/dashboards/folders.yml: config/provisioning/dashboards/folders.yml
   config/provisioning/datasources/influxdb.yml: config/provisioning/datasources/influxdb.yml
   config/provisioning/datasources/prometheus.yml: config/provisioning/datasources/prometheus.yml
+  config/provisioning/datasources/custom.yml: config/provisioning/datasources/custom.yml
   config/database_tls_client_ca.pem: config/database_tls_client_ca.pem
   config/database_tls_client_cert.pem: config/database_tls_client_cert.pem
   config/database_tls_client_key.pem: config/database_tls_client_key.pem
@@ -687,7 +688,12 @@ properties:
     description: "InfluxDB user to configure as Grafana data source"
   grafana.influxdb.password:
     description: "InfluxDB password to configure as Grafana data source"
-  
+
+  grafana.datasources.create:
+    description: "List of datasources in YAML format that Grafana will add or update during start up"
+  grafana.datasources.delete:
+    description: "List of datasources in YAML format that Grafana will delete before inserting/updating those in create list"
+
   env.http_proxy:
     description: "HTTP proxy to use"
   env.https_proxy:

--- a/jobs/grafana/templates/config/provisioning/datasources/custom.yml
+++ b/jobs/grafana/templates/config/provisioning/datasources/custom.yml
@@ -1,0 +1,9 @@
+# config file version
+apiVersion: 1
+
+# list of datasources that should be deleted from the database
+deleteDatasources: <%= p('grafana.datasources.delete', []).to_json %>
+
+# list of datasources to insert/update depending
+# what's available in the database
+datasources: <%= p('grafana.datasources.create', []).to_json %>


### PR DESCRIPTION
Opsfile example:
```yaml
- type: replace
  path: /instance_groups/name=grafana/jobs/name=grafana/properties/grafana/datasources?/delete
  value:
    - name: Cloudwatch
      orgId: 1

- type: replace
  path: /instance_groups/name=grafana/jobs/name=grafana/properties/grafana/datasources?/create
  value:
    - name: Cloudwatch
      type: cloudwatch
      orgId: 1
      jsonData:
        authType: keys
        defaultRegion: eu-central-1
      secureJsonData:
        accessKey: "<my-access-key>"
        secretKey: "<my-secret-key>"

```