### PR TITLE
Allow cert contents in prometheus scrape config tls config

### DIFF
--- a/jobs/prometheus2/spec
+++ b/jobs/prometheus2/spec
@@ -5,6 +5,7 @@ packages:
   - prometheus2
 
 templates:
+  bin/pre-start.erb: bin/pre-start
   bin/prometheus_ctl: bin/prometheus_ctl
   config/prometheus.yml: config/prometheus.yml
   config/custom.rules.yml: config/custom.rules.yml

--- a/jobs/prometheus2/templates/bin/pre-start.erb
+++ b/jobs/prometheus2/templates/bin/pre-start.erb
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+<% if_p("prometheus.scrape_configs") do |scrape_configs| %>
+  <% scrape_configs.each do |scrape_config| %>
+    <% if scrape_config['tls_config'] %>
+      <% if scrape_config['tls_config']['cert_contents'] %>
+        mkdir -p $(dirname <%= scrape_config['tls_config']['cert_file'] %>)
+        echo "<%= scrape_config['tls_config']['cert_contents'] %>" > <%= scrape_config['tls_config']['cert_file'] %>
+      <% end %>
+      <% if scrape_config['tls_config']['key_contents'] %>
+        mkdir -p $(dirname <%= scrape_config['tls_config']['key_file'] %>)
+        echo "<%= scrape_config['tls_config']['key_contents'] %>" > <%= scrape_config['tls_config']['key_file'] %>
+      <% end %>
+      <% if scrape_config['tls_config']['ca_contents'] %>
+        mkdir -p $(dirname <%= scrape_config['tls_config']['ca_file'] %>)
+        echo "<%= scrape_config['tls_config']['ca_contents'] %>" > <%= scrape_config['tls_config']['ca_file'] %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/jobs/prometheus2/templates/config/prometheus.yml
+++ b/jobs/prometheus2/templates/config/prometheus.yml
@@ -22,7 +22,15 @@ global:
 rule_files: <%= p('prometheus.rule_files', []).push('/var/vcap/jobs/prometheus2/config/custom.rules.yml').to_json %>
 
 # A list of scrape configurations.
-scrape_configs: <%= p('prometheus.scrape_configs', []).to_json %>
+<% scrape_configs = p('prometheus.scrape_configs', []).map do |scrape_config|
+
+  scrape_config = scrape_config.clone
+  scrape_config['tls_config'] = scrape_config['tls_config'].clone
+  ['ca_contents', 'cert_contents', 'key_contents'].each { |key| scrape_config['tls_config'].delete(key) } if scrape_config['tls_config']
+  scrape_config
+end %>
+
+scrape_configs: <%= scrape_configs.to_json %>
 
 # Alerting specifies settings related to the Alertmanager.
 alerting:


### PR DESCRIPTION
For context, on the Bosh team, we are trying to deploy a prometheus in our acceptance environment to try out providing our own metrics. (the bosh-exporter is cool, but very expensive to run, metrics provided directly by Bosh should be much cheaper). The bosh metrics endpoint is secured with mTLS and we need to give certs to the scrape config.

Thanks,
Charles

PR details:

Prometheus wants scrape_config tls_config to use file paths, but it is difficult
to directly put certificates on a vm while deploying with bosh.

If cert_contents are provided, the pre-start script will write the
contents into cert files that prometheus can use when it starts

Prometheus validates that there are not extra keys in its configuration,
so the extra cert contents keys need to be removed.

[#169551239](https://www.pivotaltracker.com/story/show/169551239)

Co-authored-by: Conor Nosal <cnosal@pivotal.io>
