### PR TITLE
Fix property name for max_queues

### DIFF
--- a/jobs/rabbitmq_exporter/spec
+++ b/jobs/rabbitmq_exporter/spec
@@ -34,7 +34,7 @@ properties:
     description: "Comma-separated list of extended scraping capabilities supported by the target RabbitMQ server"
   rabbitmq_exporter.rabbitmq.timeout:
     description: "Timeout in seconds for retrieving data from management plugin"
-  rabbitmq_exporter.rabbitmq.max_queue:
+  rabbitmq_exporter.rabbitmq.max_queues:
     description: "Max number of queues before we drop metrics"
   rabbitmq_exporter.rabbitmq.include_vhost:
     description: "Reqgex vhost filter. Only queues in matching vhosts are exported"


### PR DESCRIPTION
The [rabbitmq_exporter_ctl  template](https://github.com/bosh-prometheus/prometheus-boshrelease/blob/master/jobs/rabbitmq_exporter/templates/bin/rabbitmq_exporter_ctl#L61) expects the property name to be max_queues.