### PR TITLE
bump grafana 6.5.3 to 7.0.3

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -58,10 +58,9 @@ gperf/gperf-3.1.tar.gz:
   size: 1215925
   object_id: 65d1b23c-97f5-4555-719a-9c4c8cc1904f
   sha: e3c0618c2d2e5586eda9498c867d5e4858a3b0e2
-grafana/grafana-6.5.3.linux-amd64.tar.gz:
-  size: 61041681
-  object_id: fed4f46c-bbd4-44b7-598e-f0b76008a570
-  sha: sha256:02fe78f1d6842e043ca61a64272dd7dfdb4103486f163501b08a923f0f0452be
+grafana/grafana-7.0.3.linux-amd64.tar.gz:
+  size: 49416548
+  sha: sha256:8fac62da4e4bfcebce3e66c4f62fd4ed89139b06b09d0155454199ba6d4869f2
 graphite_exporter/graphite_exporter-0.6.2.linux-amd64.tar.gz:
   size: 6918576
   object_id: 823ea501-25c1-404a-5e66-7d131c9308b0

--- a/jobs/grafana/spec
+++ b/jobs/grafana/spec
@@ -629,6 +629,8 @@ properties:
     description: "Enable alpha plugins"
   grafana.plugins.app_tls_skip_verify_insecure:
     description: "Skip verify insecure for app tls"
+  grafana.plugins.allow_loading_unsigned_plugins:
+    description: "Enter a comma-separated list of plugin identifiers to identify plugins that are allowed to be loaded even if they lack a valid signature"
 
   grafana.enterprise.license:
     description: "Enterprise license"

--- a/jobs/grafana/spec
+++ b/jobs/grafana/spec
@@ -351,8 +351,6 @@ properties:
     description: "Generic OAuth TLS Client key"
   grafana.auth.generic_oauth.tls_skip_verify_insecure:
     description: "Generic OAuth TLS skip verification"
-  grafana.auth.generic_oauth.send_client_credentials_via_post:
-    description: "Genetic OAuth send client credentials via POST"
 
   grafana.auth.grafananet.enabled:
     description: "Grafana.net auth enabled"

--- a/jobs/grafana/templates/config/grafana.ini
+++ b/jobs/grafana/templates/config/grafana.ini
@@ -1244,6 +1244,10 @@ enable_alpha = <%= enable_alpha %>
 app_tls_skip_verify_insecure = <%= app_tls_skip_verify_insecure %>
 <% end %>
 
+<% if_p('grafana.plugins.allow_loading_unsigned_plugins') do |allow_loading_unsigned_plugins| %>
+allow_loading_unsigned_plugins = <%= allow_loading_unsigned_plugins %>
+<% end %>
+
 [enterprise]
 <% if_p('grafana.enterprise.license') do %>
 license_path = /var/vcap/jobs/grafana/config/license.jwt

--- a/jobs/grafana/templates/config/grafana.ini
+++ b/jobs/grafana/templates/config/grafana.ini
@@ -716,10 +716,6 @@ tls_client_key = /var/vcap/jobs/grafana/config/generic_oauth_tls_client_key.pem
 tls_skip_verify_insecure = <%= tls_skip_verify_insecure %>
 <% end %>
 
-<% if_p('grafana.auth.generic_oauth.send_client_credentials_via_post') do |send_client_credentials_via_post| %>
-send_client_credentials_via_post = <%= send_client_credentials_via_post %>
-<% end %>
-
 #################################### SAML Auth ###########################
 [auth.saml] # Enterprise only
 <% if_p('grafana.auth.saml.enabled') do |enabled| %>

--- a/packages/grafana/packaging
+++ b/packages/grafana/packaging
@@ -7,8 +7,8 @@ mkdir -p ${BOSH_INSTALL_TARGET}/common
 cp -a ${BOSH_COMPILE_TARGET}/common/* ${BOSH_INSTALL_TARGET}/common
 
 # Extract grafana package
-tar xzvf ${BOSH_COMPILE_TARGET}/grafana/grafana-6.5.3.linux-amd64.tar.gz
-cp -a ${BOSH_COMPILE_TARGET}/grafana-6.5.3/* ${BOSH_INSTALL_TARGET}
+tar xzvf ${BOSH_COMPILE_TARGET}/grafana/grafana-7.0.3.linux-amd64.tar.gz
+cp -a ${BOSH_COMPILE_TARGET}/grafana-7.0.3/* ${BOSH_INSTALL_TARGET}
 
 # Compile freetype (fontconfig dependency)
 tar xzvf ${BOSH_COMPILE_TARGET}/freetype/freetype-2.9.1.tar.gz

--- a/packages/grafana/spec
+++ b/packages/grafana/spec
@@ -3,7 +3,7 @@ name: grafana
 
 files:
   - common/utils.sh
-  - grafana/grafana-6.5.3.linux-amd64.tar.gz
+  - grafana/grafana-7.0.3.linux-amd64.tar.gz
   - fontconfig/fontconfig-2.13.92.tar.gz
   - freefont/freefont-otf-20120503.tar.gz
   - freetype/freetype-2.9.1.tar.gz


### PR DESCRIPTION
In order to leverage grafana 7.x, this PR bumps from grafana 6.5.3 to the latest of 7.0.3. The [posted changelog is listed here](https://github.com/grafana/grafana/blob/master/CHANGELOG.md#70-feature-highlights). I have tested this on a corporate-internal environment which uses CF's UAA for oauth and CF's routing-release for prometheus/alertmanager/grafana route registration, and haven't experienced any full-on failure issues.

for convenience if cross-referencing grafana conf differences, [here's the 7.0.3 defaults.ini](https://github.com/grafana/grafana/blob/v7.0.3/conf/defaults.ini), and the [grafana upgrade guide for all versions up to 7.0.3](https://grafana.com/docs/grafana/latest/installation/upgrading/)

Blobs: if accepted, blobs will need to be stored and uploaded into the blobstore:

```sh
wget https://dl.grafana.com/oss/release/grafana-7.0.3.linux-amd64.tar.gz
bosh add-blob grafana-7.0.3.linux-amd64.tar.gz grafana/grafana-7.0.3.linux-amd64.tar.gz
bosh remove-blob grafana/grafana-6.5.3.linux-amd64.tar.gz
```

## changes

- [removes `send_client_credentials_via_post`, removed in 6.6](https://grafana.com/docs/grafana/latest/installation/upgrading/#upgrading-to-v6-6)
- [phantomjs support is removed in 7.x+, but I'm not sure how significant that is?](https://grafana.com/docs/grafana/latest/installation/upgrading/#phantomjs-removed)
- [configuration option for `allow_loading_unsigned_plugins` introduced in 7.x](https://grafana.com/docs/grafana/latest/installation/configuration/#allow-loading-unsigned-plugins)