### PR TITLE
prometheus 2.15.2 to 2.19.0

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -118,10 +118,9 @@ prometheus/prometheus-1.8.2.linux-amd64.tar.gz:
   size: 17748716
   object_id: 54fd8c7b-a676-44cd-64b2-d5788552e607
   sha: 33101ac86a6376680c3b44b63db47f1754d77a1a
-prometheus/prometheus-2.15.2.linux-amd64.tar.gz:
-  size: 59204993
-  object_id: 309fe02a-4190-4bac-454b-9a7e77d9dd73
-  sha: sha256:579f800ec3ec2dc9a36d2d513e7800552cf6b0898f87a8abafd54e73b53f8ad0
+prometheus/prometheus-2.19.0.linux-amd64.tar.gz:
+  size: 64161216
+  sha: sha256:447cf576cf1796b54daa14f5017100611392d0f7ecbc029163abed2ffc8a41fa
 pushgateway/pushgateway-1.0.1.linux-amd64.tar.gz:
   size: 8970480
   object_id: 845c386a-116f-47e3-53e6-43f822f96953

--- a/packages/prometheus2/packaging
+++ b/packages/prometheus2/packaging
@@ -8,5 +8,5 @@ cp -a ${BOSH_COMPILE_TARGET}/common/* ${BOSH_INSTALL_TARGET}/common
 
 # Extract prometheus package
 mkdir -p ${BOSH_INSTALL_TARGET}/bin
-tar xzvf ${BOSH_COMPILE_TARGET}/prometheus/prometheus-2.15.2.linux-amd64.tar.gz
-cp -a ${BOSH_COMPILE_TARGET}/prometheus-2.15.2.linux-amd64/* ${BOSH_INSTALL_TARGET}/bin
+tar xzvf ${BOSH_COMPILE_TARGET}/prometheus/prometheus-2.19.0.linux-amd64.tar.gz
+cp -a ${BOSH_COMPILE_TARGET}/prometheus-2.19.0.linux-amd64/* ${BOSH_INSTALL_TARGET}/bin

--- a/packages/prometheus2/spec
+++ b/packages/prometheus2/spec
@@ -3,4 +3,4 @@ name: prometheus2
 
 files:
   - common/utils.sh
-  - prometheus/prometheus-2.15.2.linux-amd64.tar.gz
+  - prometheus/prometheus-2.19.0.linux-amd64.tar.gz


### PR DESCRIPTION
In order to leverage more efficient versions of prometheus, this PR bumps from prometheus 2.15.2 to the latest of 2.19.0. The [posted changelogs with releases is listed here](https://github.com/prometheus/prometheus/releases). I have tested this on a corporate-internal environment and haven't experienced problems.

Blobs: if accepted, blobs will need to be stored and uploaded into the blobstore:

```sh
wget https://github.com/prometheus/prometheus/releases/download/v2.19.0/prometheus-2.19.0.linux-amd64.tar.gz
bosh add-blob prometheus-2.19.0.linux-amd64.tar.gz prometheus/prometheus-2.19.0.linux-amd64.tar.gz
bosh remove-blob prometheus/prometheus-2.15.2.linux-amd64.tar.gz
```