### PR TITLE
Fixup property reference naming for grafana.feature_toggles

### DIFF
--- a/jobs/grafana/templates/config/grafana.ini
+++ b/jobs/grafana/templates/config/grafana.ini
@@ -1254,7 +1254,7 @@ license_path = /var/vcap/jobs/grafana/config/license.jwt
 <% end %>
 
 [feature_toggles]
-<% if_p('grafana.eature_toggles.enable') do |enable| %>
+<% if_p('grafana.feature_toggles.enable') do |enable| %>
 # enable features, separated by spaces
 enable = <%= enable %>
 <% end %>


### PR DESCRIPTION
Property reference in bosh template was missing `f` in `feature`. This is referenced as `grafana.feature_toggles.enable` in the grafana `spec`