### PR TITLE
Store grafana datasource credentials using secureJson

### DIFF
--- a/jobs/grafana/templates/config/provisioning/datasources/influxdb.yml
+++ b/jobs/grafana/templates/config/provisioning/datasources/influxdb.yml
@@ -22,8 +22,10 @@ datasources:
     access: proxy
     # <string> url
     url: <%= influxdb_url %>
-    # <string> database password, if used
-    password: <%= p('grafana.influxdb.password') %>
+    # <string> json object of data that will be encrypted.
+    secureJsonData:
+      # <string> database password, if used
+      password: <%= p('grafana.influxdb.password') %>
     # <string> database user, if used
     user: <%= p('grafana.influxdb.username') %>
     # <string> database name, if used

--- a/jobs/grafana/templates/config/provisioning/datasources/prometheus.yml
+++ b/jobs/grafana/templates/config/provisioning/datasources/prometheus.yml
@@ -59,12 +59,14 @@ datasources:
     basicAuth: <%= pbasic_auth %>
     # <string> basic auth username
     basicAuthUser: <%= pbasic_auth_user %>
-    # <string> basic auth password
-    basicAuthPassword: <%= pbasic_auth_password %>
     # <bool> mark as default datasource. Max one per org
     isDefault: true
     # <map> fields that will be converted to json and stored in json_data
     jsonData: <%= pjson_data %>
+    # <string> json object of data that will be encrypted.
+    secureJsonData:
+      # <string> basic auth password
+      basicAuthPassword: <%= pbasic_auth_password %>
     # <bool> allow users to edit datasources from the UI.
     editable: false
 <% end %>


### PR DESCRIPTION
In order to store datasource passwords encrypted, and to move off the deprecated configuration property formats, the values for `password` and `basicAuthPassword` should be moved under `secureJsonData`

see also:
- https://github.com/grafana/grafana/pull/16175/files/62c1d03b68f50b1f3d10f415c7b3544133865ce3
- https://grafana.com/docs/grafana/latest/administration/provisioning/#datasources