### PR TITLE
Fix CF Dashboard Issues

### DIFF
--- a/jobs/cloudfoundry_alerts/spec
+++ b/jobs/cloudfoundry_alerts/spec
@@ -159,6 +159,12 @@ properties:
   cloudfoundry_alerts.router_requests.evaluation_time:
     description: "Router Requests alert evaluation time"
     default: 5m
+  cloudfoundry_alerts.router_requests_drop.threshold:
+    description: "Total request rate over past 10 mintues is less thant X% compared to the past 4 hour average, default to 10%"
+    default: 10
+  cloudfoundry_alerts.router_requests_drop.evaluation_time:
+    description: "Router Requests sudden drop alert evaluation time"
+    default: 5m
   cloudfoundry_alerts.routers_latency.threshold:
     description: "Routers Latency alert threshold"
     default: 100

--- a/jobs/cloudfoundry_alerts/templates/cf_routers.alerts.yml
+++ b/jobs/cloudfoundry_alerts/templates/cf_routers.alerts.yml
@@ -21,6 +21,18 @@ groups:
           summary: "Requests per second at CF Router `{{$labels.environment}}/{{$labels.bosh_deployment}}/{{$labels.bosh_job_ip}}` is too high: {{$value}}req/s"
           description: "CF Router `{{$labels.environment}}/{{$labels.bosh_deployment}}/{{$labels.bosh_job_ip}}` has processed {{$value}} requests per second during the last <%= p('cloudfoundry_alerts.router_requests.evaluation_time') %>"
 
+      - alert: CFRouterRequestsTooLow
+        #Total request rate over past 10 minutes is less than cloudfoundry_alerts.router_requests_drop.threshold% of the past 4 hours,
+        # indicating severe issue at the router
+        expr: (sum(increase(firehose_http_start_stop_requests[10m])) * 24 +0.1)*100/(sum(increase(firehose_http_start_stop_requests[240m])) + 1) <  <%= p('cloudfoundry_alerts.router_requests_drop.threshold') %>
+        for: <%= p('cloudfoundry_alerts.router_requests_drop.evaluation_time') %>
+        labels:
+          service: cf
+          severity: critical
+        annotations:
+          summary: "Total requests per second have dropped too fast"
+          description: "Total requests per second across all routers has dropped below <%= p('cloudfoundry_alerts.router_requests_drop.threshold') %>% during the last <%= p('cloudfoundry_alerts.router_requests_drop.evaluation_time') %>"
+
       - alert: CFRoutersLatencyTooHigh
         expr: avg(firehose_value_metric_gorouter_latency) by(environment, bosh_deployment) > <%= p('cloudfoundry_alerts.routers_latency.threshold') %>
         for: <%= p('cloudfoundry_alerts.routers_latency.evaluation_time') %>
@@ -70,3 +82,4 @@ groups:
         annotations:
           summary: "Number of routes at CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` is too low: {{$value}}"
           description: "There has been only {{$value}} routes in the routing table at CF `{{$labels.environment}}/{{$labels.bosh_deployment}}` during the last <%= p('cloudfoundry_alerts.routes_total.evaluation_time') %>"
+

--- a/jobs/cloudfoundry_dashboards/templates/cf_apps_latency.json
+++ b/jobs/cloudfoundry_dashboards/templates/cf_apps_latency.json
@@ -104,7 +104,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_http_start_stop_client_request_duration_seconds_sum{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"} / firehose_http_start_stop_client_request_duration_seconds_count{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"})",
+          "expr": "avg(firehose_http_start_stop_client_request_duration_seconds_sum{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"} / firehose_http_start_stop_client_request_duration_seconds_count{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"})",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Client",
@@ -112,7 +112,7 @@
           "step": 2
         },
         {
-          "expr": "avg(firehose_http_start_stop_server_request_duration_seconds_sum{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"} / firehose_http_start_stop_server_request_duration_seconds_count{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"})",
+          "expr": "avg(firehose_http_start_stop_server_request_duration_seconds_sum{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"} / firehose_http_start_stop_server_request_duration_seconds_count{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"})",
           "intervalFactor": 2,
           "legendFormat": "Server",
           "refId": "B",
@@ -200,7 +200,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_http_start_stop_client_request_duration_seconds{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}) by(quantile)",
+          "expr": "avg(firehose_http_start_stop_client_request_duration_seconds{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"}) by(quantile)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ quantile }}",
@@ -289,7 +289,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_http_start_stop_server_request_duration_seconds{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}) by(quantile)",
+          "expr": "avg(firehose_http_start_stop_server_request_duration_seconds{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"}) by(quantile)",
           "intervalFactor": 2,
           "legendFormat": "{{ quantile }}",
           "refId": "A",
@@ -393,7 +393,7 @@
         "multi": false,
         "name": "cf_organization_name",
         "options": [],
-        "query": "label_values(cf_application_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\"}, organization_name)",
+        "query": "label_values(cf_application_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\"}, organization_name)",
         "refresh": 1,
         "regex": "",
         "sort": 1,
@@ -413,7 +413,7 @@
         "multi": false,
         "name": "cf_space_name",
         "options": [],
-        "query": "label_values(cf_application_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_name=~\"$cf_organization_name\"}, space_name)",
+        "query": "label_values(cf_application_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\",organization_name=~\"$cf_organization_name\"}, space_name)",
         "refresh": 1,
         "regex": "",
         "sort": 1,
@@ -433,7 +433,7 @@
         "multi": false,
         "name": "cf_application_name",
         "options": [],
-        "query": "label_values(cf_application_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_name=~\"$cf_organization_name\", space_name=~\"$cf_space_name\"}, application_name)",
+        "query": "label_values(cf_application_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\",organization_name=~\"$cf_organization_name\", space_name=~\"$cf_space_name\"}, application_name)",
         "refresh": 1,
         "regex": "",
         "sort": 1,
@@ -453,7 +453,7 @@
         "multi": false,
         "name": "cf_application_id",
         "options": [],
-        "query": "label_values(cf_application_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_name=~\"$cf_organization_name\", space_name=~\"$cf_space_name\",application_name=~\"$cf_application_name\"}, application_id)",
+        "query": "label_values(cf_application_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\",organization_name=~\"$cf_organization_name\", space_name=~\"$cf_space_name\",application_name=~\"$cf_application_name\"}, application_id)",
         "refresh": 1,
         "regex": "",
         "sort": 0,

--- a/jobs/cloudfoundry_dashboards/templates/cf_apps_requests.json
+++ b/jobs/cloudfoundry_dashboards/templates/cf_apps_requests.json
@@ -103,7 +103,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"}[5m]))",
+          "expr": "sum(rate(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"}[5m]))",
           "intervalFactor": 2,
           "legendFormat": "Requests",
           "refId": "A",
@@ -272,7 +272,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"}[5m])) by(instance_id)",
+          "expr": "sum(rate(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"}[5m])) by (instance_id)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ instance_id }}",
@@ -441,7 +441,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"}[5m])) by(method)",
+          "expr": "sum(rate(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"}[5m])) by(method)",
           "intervalFactor": 2,
           "legendFormat": "{{ method }}",
           "refId": "A",
@@ -611,7 +611,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"}[5m])) by(status_code)",
+          "expr": "sum(rate(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"}[5m])) by(status_code)",
           "intervalFactor": 2,
           "legendFormat": "{{ status_code }}",
           "refId": "A",
@@ -781,7 +781,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"}[5m])) by(scheme)",
+          "expr": "sum(rate(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"}[5m])) by(scheme)",
           "intervalFactor": 2,
           "legendFormat": "{{ scheme }}",
           "refId": "A",
@@ -951,7 +951,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"}[5m])) by(host)",
+          "expr": "sum(rate(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"}[5m])) by(host)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ host }}",

--- a/jobs/cloudfoundry_dashboards/templates/cf_apps_requests.json
+++ b/jobs/cloudfoundry_dashboards/templates/cf_apps_requests.json
@@ -103,7 +103,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}[5m]))",
+          "expr": "avg(rate(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"}[5m]))",
           "intervalFactor": 2,
           "legendFormat": "Requests",
           "refId": "A",
@@ -189,7 +189,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"})",
+          "expr": "sum(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"})",
           "intervalFactor": 2,
           "legendFormat": "Requests",
           "refId": "A",
@@ -272,7 +272,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}[5m])) by(instance_id)",
+          "expr": "avg(rate(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"}[5m])) by(instance_id)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ instance_id }}",
@@ -355,7 +355,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}) by(instance_id)",
+          "expr": "sum(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"}) by(instance_id)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ instance_id }}",
@@ -441,7 +441,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}[5m])) by(method)",
+          "expr": "avg(rate(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"}[5m])) by(method)",
           "intervalFactor": 2,
           "legendFormat": "{{ method }}",
           "refId": "A",
@@ -526,7 +526,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}) by(method)",
+          "expr": "sum(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"}) by(method)",
           "intervalFactor": 2,
           "legendFormat": "{{ method }}",
           "refId": "A",
@@ -611,7 +611,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}[5m])) by(status_code)",
+          "expr": "avg(rate(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"}[5m])) by(status_code)",
           "intervalFactor": 2,
           "legendFormat": "{{ status_code }}",
           "refId": "A",
@@ -696,7 +696,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}) by(status_code)",
+          "expr": "sum(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"}) by(status_code)",
           "intervalFactor": 2,
           "legendFormat": "{{ status_code }}",
           "refId": "A",
@@ -781,7 +781,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}[5m])) by(scheme)",
+          "expr": "avg(rate(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"}[5m])) by(scheme)",
           "intervalFactor": 2,
           "legendFormat": "{{ scheme }}",
           "refId": "A",
@@ -866,7 +866,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}) by(scheme)",
+          "expr": "sum(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"}) by(scheme)",
           "intervalFactor": 2,
           "legendFormat": "{{ scheme }}",
           "refId": "A",
@@ -951,7 +951,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}[5m])) by(host)",
+          "expr": "avg(rate(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"}[5m])) by(host)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ host }}",
@@ -1037,7 +1037,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}) by(host)",
+          "expr": "sum(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"}) by(host)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ host }}",
@@ -1122,7 +1122,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_http_start_stop_response_size_bytes_sum{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"} / firehose_http_start_stop_response_size_bytes_count{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"})",
+          "expr": "avg(firehose_http_start_stop_response_size_bytes_sum{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"} / firehose_http_start_stop_response_size_bytes_count{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"})",
           "intervalFactor": 2,
           "legendFormat": "Size",
           "refId": "A",
@@ -1206,7 +1206,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_http_start_stop_response_size_bytes{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}) by(quantile)",
+          "expr": "avg(firehose_http_start_stop_response_size_bytes{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"}) by(quantile)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ quantile }}",
@@ -1310,7 +1310,7 @@
         "multi": false,
         "name": "cf_organization_name",
         "options": [],
-        "query": "label_values(cf_application_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\"}, organization_name)",
+        "query": "label_values(cf_application_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\"}, organization_name)",
         "refresh": 1,
         "regex": "",
         "sort": 1,
@@ -1330,7 +1330,7 @@
         "multi": false,
         "name": "cf_space_name",
         "options": [],
-        "query": "label_values(cf_application_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_name=~\"$cf_organization_name\"}, space_name)",
+        "query": "label_values(cf_application_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\",organization_name=~\"$cf_organization_name\"}, space_name)",
         "refresh": 1,
         "regex": "",
         "sort": 1,
@@ -1350,7 +1350,7 @@
         "multi": false,
         "name": "cf_application_name",
         "options": [],
-        "query": "label_values(cf_application_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_name=~\"$cf_organization_name\", space_name=~\"$cf_space_name\"}, application_name)",
+        "query": "label_values(cf_application_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\",organization_name=~\"$cf_organization_name\", space_name=~\"$cf_space_name\"}, application_name)",
         "refresh": 1,
         "regex": "",
         "sort": 1,
@@ -1370,7 +1370,7 @@
         "multi": false,
         "name": "cf_application_id",
         "options": [],
-        "query": "label_values(cf_application_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_name=~\"$cf_organization_name\", space_name=~\"$cf_space_name\",application_name=~\"$cf_application_name\"}, application_id)",
+        "query": "label_values(cf_application_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\",organization_name=~\"$cf_organization_name\", space_name=~\"$cf_space_name\",application_name=~\"$cf_application_name\"}, application_id)",
         "refresh": 1,
         "regex": "",
         "sort": 0,

--- a/jobs/cloudfoundry_dashboards/templates/cf_apps_system.json
+++ b/jobs/cloudfoundry_dashboards/templates/cf_apps_system.json
@@ -136,7 +136,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "count(cf_application_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}) by(state)",
+          "expr": "count(cf_application_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"}) by(state)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -197,7 +197,7 @@
       ],
       "targets": [
         {
-          "expr": "count(firehose_container_metric_cpu_percentage{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}) by(instance_index,  bosh_job_ip)",
+          "expr": "count(firehose_container_metric_cpu_percentage{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"}) by(instance_index,  bosh_job_ip)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -249,7 +249,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "min(cf_application_instances{environment=~\"$environment\",deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"})",
+          "expr": "min(cf_application_instances{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Desired",
@@ -257,7 +257,7 @@
           "step": 10
         },
         {
-          "expr": "min(cf_application_instances_running{environment=~\"$environment\",deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"})",
+          "expr": "min(cf_application_instances_running{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"})",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -347,7 +347,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_container_metric_cpu_percentage{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"})",
+          "expr": "avg(firehose_container_metric_cpu_percentage{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -432,7 +432,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_container_metric_cpu_percentage{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}) by(instance_index) ",
+          "expr": "avg(firehose_container_metric_cpu_percentage{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"}) by(instance_index) ",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -529,7 +529,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_container_metric_memory_bytes{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"})",
+          "expr": "avg(firehose_container_metric_memory_bytes{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"})",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Used",
@@ -537,7 +537,7 @@
           "step": 10
         },
         {
-          "expr": "avg(firehose_container_metric_memory_bytes_quota{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"})",
+          "expr": "avg(firehose_container_metric_memory_bytes_quota{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"})",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Quota",
@@ -621,7 +621,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_container_metric_memory_bytes{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}) by(instance_index) ",
+          "expr": "avg(firehose_container_metric_memory_bytes{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"}) by(instance_index) ",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{ instance_index }}",
@@ -629,7 +629,7 @@
           "step": 10
         },
         {
-          "expr": "avg(firehose_container_metric_memory_bytes_quota{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"})",
+          "expr": "avg(firehose_container_metric_memory_bytes_quota{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -726,7 +726,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_container_metric_disk_bytes{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"})",
+          "expr": "avg(firehose_container_metric_disk_bytes{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -735,7 +735,7 @@
           "step": 10
         },
         {
-          "expr": "avg(firehose_container_metric_disk_bytes_quota{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"})",
+          "expr": "avg(firehose_container_metric_disk_bytes_quota{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"})",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -820,7 +820,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_container_metric_disk_bytes{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}) by(instance_index) ",
+          "expr": "avg(firehose_container_metric_disk_bytes{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"}) by(instance_index) ",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ instance_index }}",
@@ -828,7 +828,7 @@
           "step": 10
         },
         {
-          "expr": "avg(firehose_container_metric_disk_bytes_quota{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"})",
+          "expr": "avg(firehose_container_metric_disk_bytes_quota{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"})",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Quota",
@@ -932,7 +932,7 @@
         "multi": false,
         "name": "cf_organization_name",
         "options": [],
-        "query": "label_values(cf_application_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\"}, organization_name)",
+        "query": "label_values(cf_application_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\"}, organization_name)",
         "refresh": 1,
         "regex": "",
         "sort": 1,
@@ -952,7 +952,7 @@
         "multi": false,
         "name": "cf_space_name",
         "options": [],
-        "query": "label_values(cf_application_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_name=~\"$cf_organization_name\"}, space_name)",
+        "query": "label_values(cf_application_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\",organization_name=~\"$cf_organization_name\"}, space_name)",
         "refresh": 1,
         "regex": "",
         "sort": 1,
@@ -972,7 +972,7 @@
         "multi": false,
         "name": "cf_application_name",
         "options": [],
-        "query": "label_values(cf_application_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_name=~\"$cf_organization_name\", space_name=~\"$cf_space_name\"}, application_name)",
+        "query": "label_values(cf_application_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\",organization_name=~\"$cf_organization_name\", space_name=~\"$cf_space_name\"}, application_name)",
         "refresh": 1,
         "regex": "",
         "sort": 1,
@@ -992,7 +992,7 @@
         "multi": false,
         "name": "cf_application_id",
         "options": [],
-        "query": "label_values(cf_application_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_name=~\"$cf_organization_name\", space_name=~\"$cf_space_name\",application_name=~\"$cf_application_name\"}, application_id)",
+        "query": "label_values(cf_application_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\",organization_name=~\"$cf_organization_name\", space_name=~\"$cf_space_name\",application_name=~\"$cf_application_name\"}, application_id)",
         "refresh": 1,
         "regex": "",
         "sort": 0,

--- a/jobs/cloudfoundry_dashboards/templates/cf_bbs.json
+++ b/jobs/cloudfoundry_dashboards/templates/cf_bbs.json
@@ -111,7 +111,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(firehose_counter_event_bbs_request_count_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_bbs_request_count_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "Requests",
           "refId": "A",
@@ -198,7 +198,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_value_metric_bbs_request_latency{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
+          "expr": "avg(firehose_value_metric_bbs_request_latency{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ bosh_deployment }}/{{ bosh_job_name }}/{{ bosh_job_ip }}",
@@ -285,7 +285,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(firehose_counter_event_bbs_convergence_lrp_runs_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_bbs_convergence_lrp_runs_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "LRPs",
@@ -293,7 +293,7 @@
           "step": 4
         },
         {
-          "expr": "sum(avg(firehose_counter_event_bbs_convergence_task_runs_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"})  by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_bbs_convergence_task_runs_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"})  by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "Tasks",
           "refId": "B",
@@ -379,14 +379,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(firehose_counter_event_bbs_convergence_tasks_kicked_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_bbs_convergence_tasks_kicked_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "Kicked",
           "refId": "A",
           "step": 4
         },
         {
-          "expr": "sum(avg(firehose_counter_event_bbs_convergence_tasks_pruned_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_bbs_convergence_tasks_pruned_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "Pruned",
           "refId": "B",
@@ -474,14 +474,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_value_metric_bbs_convergence_lrp_duration{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"})",
+          "expr": "avg(firehose_value_metric_bbs_convergence_lrp_duration{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"})",
           "intervalFactor": 2,
           "legendFormat": "LRPs",
           "refId": "A",
           "step": 4
         },
         {
-          "expr": "avg(firehose_value_metric_bbs_convergence_task_duration{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"})",
+          "expr": "avg(firehose_value_metric_bbs_convergence_task_duration{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"})",
           "intervalFactor": 2,
           "legendFormat": "Tasks",
           "refId": "B",
@@ -564,21 +564,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(firehose_counter_event_bbs_convergence_lrp_pre_processing_actual_lr_ps_deleted_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_bbs_convergence_lrp_pre_processing_actual_lr_ps_deleted_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "Deleted",
           "refId": "A",
           "step": 4
         },
         {
-          "expr": "sum(avg(firehose_counter_event_bbs_convergence_lrp_pre_processing_malformed_run_infos_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_bbs_convergence_lrp_pre_processing_malformed_run_infos_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "Malformed Runs",
           "refId": "B",
           "step": 4
         },
         {
-          "expr": "sum(avg(firehose_counter_event_bbs_convergence_lrp_pre_processing_malformed_scheduling_infos_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_bbs_convergence_lrp_pre_processing_malformed_scheduling_infos_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "Malformed Scheduling",
           "refId": "C",

--- a/jobs/cloudfoundry_dashboards/templates/cf_cc.json
+++ b/jobs/cloudfoundry_dashboards/templates/cf_cc.json
@@ -109,7 +109,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(firehose_value_metric_cc_requests_completed{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}[5m]))",
+          "expr": "avg(rate(firehose_value_metric_cc_requests_completed{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}[5m]))",
           "intervalFactor": 2,
           "legendFormat": "Requests",
           "refId": "A",
@@ -197,35 +197,35 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(firehose_value_metric_cc_http_status_1_xx{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_cc_http_status_1_xx{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "1xx",
           "refId": "A",
           "step": 4
         },
         {
-          "expr": "sum(avg(firehose_value_metric_cc_http_status_2_xx{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_cc_http_status_2_xx{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "2xx",
           "refId": "B",
           "step": 4
         },
         {
-          "expr": "sum(avg(firehose_value_metric_cc_http_status_3_xx{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_cc_http_status_3_xx{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "3xx",
           "refId": "C",
           "step": 4
         },
         {
-          "expr": "sum(avg(firehose_value_metric_cc_http_status_4_xx{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_cc_http_status_4_xx{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "4xx",
           "refId": "D",
           "step": 4
         },
         {
-          "expr": "sum(avg(firehose_value_metric_cc_http_status_5_xx{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_cc_http_status_5_xx{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "5xx",
           "refId": "E",
@@ -310,7 +310,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_value_metric_cc_job_queue_length_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
+          "expr": "avg(firehose_value_metric_cc_job_queue_length_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ bosh_deployment }}/{{ bosh_job_name }}/{{ bosh_job_ip }}",
@@ -396,7 +396,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_value_metric_cc_failed_job_count_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
+          "expr": "avg(firehose_value_metric_cc_failed_job_count_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ bosh_deployment }}/{{ bosh_job_name }}/{{ bosh_job_ip }}",
@@ -482,14 +482,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(firehose_value_metric_cc_requests_completed{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_cc_requests_completed{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "Completed",
           "refId": "A",
           "step": 4
         },
         {
-          "expr": "sum(avg(firehose_value_metric_cc_requests_outstanding{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_cc_requests_outstanding{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "Outstanding",
           "refId": "B",
@@ -574,56 +574,56 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(firehose_value_metric_cc_log_count_info{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_cc_log_count_info{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "info",
           "refId": "A",
           "step": 4
         },
         {
-          "expr": "sum(avg(firehose_value_metric_cc_log_count_warn{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_cc_log_count_warn{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "warn",
           "refId": "B",
           "step": 4
         },
         {
-          "expr": "sum(avg(firehose_value_metric_cc_log_count_debug{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_cc_log_count_debug{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "debug",
           "refId": "C",
           "step": 4
         },
         {
-          "expr": "sum(avg(firehose_value_metric_cc_log_count_debug_1{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_cc_log_count_debug_1{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "debug1",
           "refId": "D",
           "step": 4
         },
         {
-          "expr": "sum(avg(firehose_value_metric_cc_log_count_debug_2{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_cc_log_count_debug_2{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "debug2",
           "refId": "E",
           "step": 4
         },
         {
-          "expr": "sum(avg(firehose_value_metric_cc_log_count_error{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_cc_log_count_error{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "error",
           "refId": "F",
           "step": 4
         },
         {
-          "expr": "sum(avg(firehose_value_metric_cc_log_count_fatal{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_cc_log_count_fatal{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "fatal",
           "refId": "G",
           "step": 4
         },
         {
-          "expr": "sum(avg(firehose_value_metric_cc_log_count_off{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_cc_log_count_off{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "off",
           "refId": "H",

--- a/jobs/cloudfoundry_dashboards/templates/cf_cell_summary.json
+++ b/jobs/cloudfoundry_dashboards/templates/cf_cell_summary.json
@@ -144,7 +144,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "max(firehose_value_metric_rep_garden_health_check_failed{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\", bosh_job_name=~\"$bosh_job_name\", bosh_job_ip=~\"$bosh_job_ip\"})",
+          "expr": "max(firehose_value_metric_rep_garden_health_check_failed{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\", bosh_job_name=~\"$bosh_job_name\", bosh_job_ip=~\"$bosh_job_ip\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",
@@ -238,7 +238,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(avg(firehose_value_metric_rep_capacity_remaining_containers{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",bosh_job_name=~\"$bosh_job_name\", bosh_job_ip=~\"$bosh_job_ip\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_rep_capacity_remaining_containers{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}\",bosh_job_name=~\"$bosh_job_name\", bosh_job_ip=~\"$bosh_job_ip\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",
@@ -323,7 +323,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(avg(firehose_value_metric_rep_capacity_remaining_memory{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",bosh_job_name=~\"$bosh_job_name\", bosh_job_ip=~\"$bosh_job_ip\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_rep_capacity_remaining_memory{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",bosh_job_name=~\"$bosh_job_name\", bosh_job_ip=~\"$bosh_job_ip\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",
@@ -408,7 +408,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(avg(firehose_value_metric_rep_capacity_remaining_disk{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",bosh_job_name=~\"$bosh_job_name\", bosh_job_ip=~\"$bosh_job_ip\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_rep_capacity_remaining_disk{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",bosh_job_name=~\"$bosh_job_name\", bosh_job_ip=~\"$bosh_job_ip\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",
@@ -470,7 +470,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(firehose_value_metric_rep_capacity_total_containers{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",bosh_job_name=~\"$bosh_job_name\", bosh_job_ip=~\"$bosh_job_ip\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)) - sum(avg(firehose_value_metric_rep_capacity_remaining_containers{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",bosh_job_name=~\"$bosh_job_name\", bosh_job_ip=~\"$bosh_job_ip\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_rep_capacity_total_containers{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}\",bosh_job_name=~\"$bosh_job_name\", bosh_job_ip=~\"$bosh_job_ip\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)) - sum(avg(firehose_value_metric_rep_capacity_remaining_containers{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}\",bosh_job_name=~\"$bosh_job_name\", bosh_job_ip=~\"$bosh_job_ip\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Used",
@@ -478,7 +478,7 @@
           "step": 4
         },
         {
-          "expr": "sum(avg(firehose_value_metric_rep_capacity_remaining_containers{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",bosh_job_name=~\"$bosh_job_name\", bosh_job_ip=~\"$bosh_job_ip\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_rep_capacity_remaining_containers{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}\",bosh_job_name=~\"$bosh_job_name\", bosh_job_ip=~\"$bosh_job_ip\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Available",
@@ -561,7 +561,7 @@
       ],
       "targets": [
         {
-          "expr": "avg(firehose_container_metric_cpu_percentage{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",bosh_job_name=~\"$bosh_job_name\", bosh_job_ip=~\"$bosh_job_ip\"}) by(application_id, instance_index) * on(application_id) group_left(organization_name, space_name, application_name) min(cf_application_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\"}) by(organization_name, space_name, application_name,  application_id)",
+          "expr": "avg(firehose_container_metric_cpu_percentage{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",bosh_job_name=~\"$bosh_job_name\", bosh_job_ip=~\"$bosh_job_ip\"}) by(application_id, instance_index) * on(application_id) group_left(organization_name, space_name, application_name) min(cf_application_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(organization_name, space_name, application_name,  application_id)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -618,7 +618,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(firehose_value_metric_rep_capacity_total_memory{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",bosh_job_name=~\"$bosh_job_name\", bosh_job_ip=~\"$bosh_job_ip\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)) - sum(avg(firehose_value_metric_rep_capacity_remaining_memory{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",bosh_job_name=~\"$bosh_job_name\", bosh_job_ip=~\"$bosh_job_ip\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_rep_capacity_total_memory{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",bosh_job_name=~\"$bosh_job_name\", bosh_job_ip=~\"$bosh_job_ip\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)) - sum(avg(firehose_value_metric_rep_capacity_remaining_memory{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",bosh_job_name=~\"$bosh_job_name\", bosh_job_ip=~\"$bosh_job_ip\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -627,7 +627,7 @@
           "step": 4
         },
         {
-          "expr": "sum(avg(firehose_value_metric_rep_capacity_remaining_memory{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",bosh_job_name=~\"$bosh_job_name\", bosh_job_ip=~\"$bosh_job_ip\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_rep_capacity_remaining_memory{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",bosh_job_name=~\"$bosh_job_name\", bosh_job_ip=~\"$bosh_job_ip\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Available",
@@ -731,7 +731,7 @@
       ],
       "targets": [
         {
-          "expr": "min(firehose_container_metric_memory_bytes{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",bosh_job_name=~\"$bosh_job_name\", bosh_job_ip=~\"$bosh_job_ip\"}) by(application_id, instance_index) * on(application_id) group_left(organization_name, space_name, application_name) min(cf_application_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\"}) by(organization_name, space_name, application_name,  application_id)",
+          "expr": "min(firehose_container_metric_memory_bytes{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",bosh_job_name=~\"$bosh_job_name\", bosh_job_ip=~\"$bosh_job_ip\"}) by(application_id, instance_index) * on(application_id) group_left(organization_name, space_name, application_name) min(cf_application_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(organization_name, space_name, application_name,  application_id)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -788,7 +788,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(firehose_value_metric_rep_capacity_total_disk{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",bosh_job_name=~\"$bosh_job_name\", bosh_job_ip=~\"$bosh_job_ip\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)) - sum(avg(firehose_value_metric_rep_capacity_remaining_disk{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",bosh_job_name=~\"$bosh_job_name\", bosh_job_ip=~\"$bosh_job_ip\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_rep_capacity_total_disk{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",bosh_job_name=~\"$bosh_job_name\", bosh_job_ip=~\"$bosh_job_ip\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)) - sum(avg(firehose_value_metric_rep_capacity_remaining_disk{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",bosh_job_name=~\"$bosh_job_name\", bosh_job_ip=~\"$bosh_job_ip\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Allocated",
@@ -796,7 +796,7 @@
           "step": 4
         },
         {
-          "expr": "sum(avg(firehose_value_metric_rep_capacity_remaining_disk{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",bosh_job_name=~\"$bosh_job_name\", bosh_job_ip=~\"$bosh_job_ip\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_rep_capacity_remaining_disk{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",bosh_job_name=~\"$bosh_job_name\", bosh_job_ip=~\"$bosh_job_ip\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Available",
@@ -901,7 +901,7 @@
       ],
       "targets": [
         {
-          "expr": "min(firehose_container_metric_disk_bytes{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",bosh_job_name=~\"$bosh_job_name\", bosh_job_ip=~\"$bosh_job_ip\"}) by(application_id, instance_index) * on(application_id) group_left(organization_name, space_name, application_name) min(cf_application_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\"}) by(organization_name, space_name, application_name,  application_id)",
+          "expr": "min(firehose_container_metric_disk_bytes{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",bosh_job_name=~\"$bosh_job_name\", bosh_job_ip=~\"$bosh_job_ip\"}) by(application_id, instance_index) * on(application_id) group_left(organization_name, space_name, application_name) min(cf_application_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(organization_name, space_name, application_name,  application_id)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{ organization_name }} / {{ space_name }} / {{ application_name }} #{{ instance_index }}",
@@ -974,7 +974,7 @@
         "multi": false,
         "name": "bosh_job_name",
         "options": [],
-        "query": "label_values(firehose_value_metric_rep_capacity_total_containers{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}, bosh_job_name)",
+        "query": "label_values(firehose_value_metric_rep_capacity_total_containers{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}\"}, bosh_job_name)",
         "refresh": 1,
         "regex": "",
         "sort": 1,
@@ -994,7 +994,7 @@
         "multi": false,
         "name": "bosh_job_ip",
         "options": [],
-        "query": "label_values(firehose_value_metric_rep_capacity_total_containers{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\", bosh_job_name=~\"$bosh_job_name\"}, bosh_job_ip)",
+        "query": "label_values(firehose_value_metric_rep_capacity_total_containers{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}\", bosh_job_name=~\"$bosh_job_name\"}, bosh_job_ip)",
         "refresh": 1,
         "regex": "",
         "sort": 1,

--- a/jobs/cloudfoundry_dashboards/templates/cf_cells_capacity.json
+++ b/jobs/cloudfoundry_dashboards/templates/cf_cells_capacity.json
@@ -143,7 +143,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "min(count(firehose_value_metric_rep_capacity_total_containers{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",bosh_job_name=~\"$bosh_job_name\"}) by(instance))",
+          "expr": "min(count(firehose_value_metric_rep_capacity_total_containers{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}\",bosh_job_name=~\"$bosh_job_name\"}) by(instance))",
           "intervalFactor": 2,
           "metric": "firehose_value_metric_rep_capacity_total_containers",
           "refId": "A",
@@ -226,7 +226,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "min(min(firehose_value_metric_rep_capacity_remaining_memory{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",bosh_job_name=~\"$bosh_job_name\"}) by(instance))",
+          "expr": "min(min(firehose_value_metric_rep_capacity_remaining_memory{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}\",bosh_job_name=~\"$bosh_job_name\"}) by(instance))",
           "format": "time_series",
           "intervalFactor": 2,
           "metric": "firehose_value_metric_rep_capacity_remaining_memory",
@@ -312,7 +312,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "bottomk(1, min(firehose_value_metric_rep_capacity_remaining_memory{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",bosh_job_name=~\"$bosh_job_name\"}) by(bosh_job_ip))",
+          "expr": "bottomk(1, min(firehose_value_metric_rep_capacity_remaining_memory{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}\",bosh_job_name=~\"$bosh_job_name\"}) by(bosh_job_ip))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ bosh_job_ip }}",
@@ -380,7 +380,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(firehose_value_metric_rep_capacity_total_memory{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",bosh_job_name=~\"$bosh_job_name\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)) - sum(avg(firehose_value_metric_rep_capacity_remaining_memory{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",bosh_job_name=~\"$bosh_job_name\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_rep_capacity_total_memory{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}\",bosh_job_name=~\"$bosh_job_name\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)) - sum(avg(firehose_value_metric_rep_capacity_remaining_memory{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}\",bosh_job_name=~\"$bosh_job_name\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Used",
@@ -388,7 +388,7 @@
           "step": 2
         },
         {
-          "expr": "sum(avg(firehose_value_metric_rep_capacity_remaining_memory{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",bosh_job_name=~\"$bosh_job_name\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_rep_capacity_remaining_memory{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}\",bosh_job_name=~\"$bosh_job_name\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "Available",
           "refId": "B",
@@ -476,14 +476,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(firehose_value_metric_rep_capacity_total_disk{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",bosh_job_name=~\"$bosh_job_name\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)) - sum(avg(firehose_value_metric_rep_capacity_remaining_disk{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",bosh_job_name=~\"$bosh_job_name\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_rep_capacity_total_disk{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}\",bosh_job_name=~\"$bosh_job_name\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)) - sum(avg(firehose_value_metric_rep_capacity_remaining_disk{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}\",bosh_job_name=~\"$bosh_job_name\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "Used",
           "refId": "A",
           "step": 2
         },
         {
-          "expr": "sum(avg(firehose_value_metric_rep_capacity_remaining_disk{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",bosh_job_name=~\"$bosh_job_name\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_rep_capacity_remaining_disk{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}\",bosh_job_name=~\"$bosh_job_name\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "Available",
           "refId": "B",
@@ -560,7 +560,7 @@
       "strokeWidth": 1,
       "targets": [
         {
-          "expr": "avg(firehose_value_metric_rep_capacity_total_containers{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",bosh_job_name=~\"$bosh_job_name\"} - firehose_value_metric_rep_capacity_remaining_containers{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",bosh_job_name=~\"$bosh_job_name\"}) by(bosh_job_ip)",
+          "expr": "avg(firehose_value_metric_rep_capacity_total_containers{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}\",bosh_job_name=~\"$bosh_job_name\"} - firehose_value_metric_rep_capacity_remaining_containers{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}\",bosh_job_name=~\"$bosh_job_name\"}) by(bosh_job_ip)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ bosh_job_ip }}",
@@ -604,7 +604,7 @@
       "strokeWidth": 1,
       "targets": [
         {
-          "expr": "avg(firehose_value_metric_rep_capacity_total_memory{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",bosh_job_name=~\"$bosh_job_name\"} - firehose_value_metric_rep_capacity_remaining_memory{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",bosh_job_name=~\"$bosh_job_name\"}) by(bosh_job_ip)",
+          "expr": "avg(firehose_value_metric_rep_capacity_total_memory{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}\",bosh_job_name=~\"$bosh_job_name\"} - firehose_value_metric_rep_capacity_remaining_memory{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}\",bosh_job_name=~\"$bosh_job_name\"}) by(bosh_job_ip)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -678,7 +678,7 @@
         "multi": true,
         "name": "bosh_job_name",
         "options": [],
-        "query": "label_values(firehose_value_metric_rep_capacity_total_containers{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}, bosh_job_name)",
+        "query": "label_values(firehose_value_metric_rep_capacity_total_containers{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}\"}, bosh_job_name)",
         "refresh": 1,
         "regex": "",
         "sort": 1,

--- a/jobs/cloudfoundry_dashboards/templates/cf_component_metrics.json
+++ b/jobs/cloudfoundry_dashboards/templates/cf_component_metrics.json
@@ -110,7 +110,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_value_metric_[[cf_component]]_num_cpus{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
+          "expr": "avg(firehose_value_metric_[[cf_component]]_num_cpus{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ bosh_deployment }}/{{ bosh_job_name }}/{{ bosh_job_ip }}",
@@ -196,7 +196,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_value_metric_[[cf_component]]_num_go_routines{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
+          "expr": "avg(firehose_value_metric_[[cf_component]]_num_go_routines{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
           "intervalFactor": 2,
           "legendFormat": "{{ bosh_deployment }}/{{ bosh_job_name }}/{{ bosh_job_ip }}",
           "refId": "A",
@@ -279,7 +279,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_value_metric_[[cf_component]]_memory_stats_num_bytes_allocated{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
+          "expr": "avg(firehose_value_metric_[[cf_component]]_memory_stats_num_bytes_allocated{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
           "intervalFactor": 2,
           "legendFormat": "{{ bosh_deployment }}/{{ bosh_job_name }}/{{ bosh_job_ip }}",
           "metric": "",
@@ -365,7 +365,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_value_metric_[[cf_component]]_memory_stats_num_bytes_allocated_stack{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
+          "expr": "avg(firehose_value_metric_[[cf_component]]_memory_stats_num_bytes_allocated_stack{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ bosh_deployment }}/{{ bosh_job_name }}/{{ bosh_job_ip }}",
@@ -452,7 +452,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_value_metric_[[cf_component]]_memory_stats_num_bytes_allocated_heap{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
+          "expr": "avg(firehose_value_metric_[[cf_component]]_memory_stats_num_bytes_allocated_heap{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
           "intervalFactor": 2,
           "legendFormat": "{{ bosh_deployment }}/{{ bosh_job_name }}/{{ bosh_job_ip }}",
           "metric": "",
@@ -538,7 +538,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_value_metric_[[cf_component]]_memory_stats_last_gc_pause_time_ns{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
+          "expr": "avg(firehose_value_metric_[[cf_component]]_memory_stats_last_gc_pause_time_ns{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
           "intervalFactor": 2,
           "legendFormat": "{{ bosh_deployment }}/{{ bosh_job_name }}/{{ bosh_job_ip }}",
           "refId": "A",
@@ -623,7 +623,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_value_metric_[[cf_component]]_memory_stats_num_mallocs{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
+          "expr": "avg(firehose_value_metric_[[cf_component]]_memory_stats_num_mallocs{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
           "intervalFactor": 2,
           "legendFormat": "{{ bosh_deployment }}/{{ bosh_job_name }}/{{ bosh_job_ip }}",
           "refId": "A",
@@ -708,7 +708,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_value_metric_[[cf_component]]_memory_stats_num_frees{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
+          "expr": "avg(firehose_value_metric_[[cf_component]]_memory_stats_num_frees{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ bosh_deployment }}/{{ bosh_job_name }}/{{ bosh_job_ip }}",

--- a/jobs/cloudfoundry_dashboards/templates/cf_component_metrics_v2.json
+++ b/jobs/cloudfoundry_dashboards/templates/cf_component_metrics_v2.json
@@ -110,7 +110,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_value_metric_[[cf_component]]_num_go_routines{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
+          "expr": "avg(firehose_value_metric_[[cf_component]]_num_go_routines{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
           "intervalFactor": 2,
           "legendFormat": "{{ bosh_deployment }}/{{ bosh_job_name }}/{{ bosh_job_ip }}",
           "refId": "A",
@@ -195,7 +195,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_value_metric_[[cf_component]]_memory_stats_last_gc_pause_time_ns{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
+          "expr": "avg(firehose_value_metric_[[cf_component]]_memory_stats_last_gc_pause_time_ns{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
           "intervalFactor": 2,
           "legendFormat": "{{ bosh_deployment }}/{{ bosh_job_name }}/{{ bosh_job_ip }}",
           "refId": "A",
@@ -278,7 +278,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_value_metric_[[cf_component]]_memory_stats_num_bytes_allocated_heap{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
+          "expr": "avg(firehose_value_metric_[[cf_component]]_memory_stats_num_bytes_allocated_heap{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
           "intervalFactor": 2,
           "legendFormat": "{{ bosh_deployment }}/{{ bosh_job_name }}/{{ bosh_job_ip }}",
           "metric": "",
@@ -364,7 +364,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_value_metric_[[cf_component]]_memory_stats_num_bytes_allocated_stack{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
+          "expr": "avg(firehose_value_metric_[[cf_component]]_memory_stats_num_bytes_allocated_stack{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ bosh_deployment }}/{{ bosh_job_name }}/{{ bosh_job_ip }}",

--- a/jobs/cloudfoundry_dashboards/templates/cf_diego_auctions.json
+++ b/jobs/cloudfoundry_dashboards/templates/cf_diego_auctions.json
@@ -111,7 +111,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(firehose_counter_event_auctioneer_auctioneer_lrp_auctions_failed_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_auctioneer_auctioneer_lrp_auctions_failed_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "Failed LPRs",
           "metric": "",
@@ -119,7 +119,7 @@
           "step": 4
         },
         {
-          "expr": "sum(avg(firehose_counter_event_auctioneer_auctioneer_lrp_auctions_started_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_auctioneer_auctioneer_lrp_auctions_started_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Started LPRs",
@@ -127,14 +127,14 @@
           "step": 4
         },
         {
-          "expr": "sum(avg(firehose_counter_event_auctioneer_auctioneer_task_auctions_failed_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_auctioneer_auctioneer_task_auctions_failed_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "Failed Tasks",
           "refId": "C",
           "step": 4
         },
         {
-          "expr": "sum(avg(firehose_counter_event_auctioneer_auctioneer_task_auctions_started_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_auctioneer_auctioneer_task_auctions_started_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "Started Tasks",
           "refId": "D",
@@ -219,7 +219,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(firehose_counter_event_auctioneer_auctioneer_lrp_auctions_started_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}[5m]))",
+          "expr": "avg(rate(firehose_counter_event_auctioneer_auctioneer_lrp_auctions_started_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}[5m]))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "LRPs",
@@ -227,7 +227,7 @@
           "step": 4
         },
         {
-          "expr": "avg(rate(firehose_counter_event_auctioneer_auctioneer_task_auctions_started_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}[5m]))",
+          "expr": "avg(rate(firehose_counter_event_auctioneer_auctioneer_task_auctions_started_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}[5m]))",
           "intervalFactor": 2,
           "legendFormat": "Tasks",
           "refId": "B",
@@ -313,7 +313,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_value_metric_auctioneer_auctioneer_fetch_states_duration{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"})",
+          "expr": "avg(firehose_value_metric_auctioneer_auctioneer_fetch_states_duration{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"})",
           "intervalFactor": 2,
           "legendFormat": "Duration",
           "refId": "A",
@@ -399,7 +399,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_value_metric_auctioneer_request_latency{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"})",
+          "expr": "avg(firehose_value_metric_auctioneer_request_latency{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"})",
           "intervalFactor": 2,
           "legendFormat": "Latency",
           "refId": "A",

--- a/jobs/cloudfoundry_dashboards/templates/cf_diego_health.json
+++ b/jobs/cloudfoundry_dashboards/templates/cf_diego_health.json
@@ -140,7 +140,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "min(firehose_value_metric_bbs_domain_cf_apps{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"})",
+          "expr": "min(firehose_value_metric_bbs_domain_cf_apps{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"})",
           "intervalFactor": 2,
           "refId": "A",
           "step": 2
@@ -236,7 +236,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "min(firehose_value_metric_bbs_domain_cf_tasks{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"})",
+          "expr": "min(firehose_value_metric_bbs_domain_cf_tasks{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"})",
           "intervalFactor": 2,
           "refId": "A",
           "step": 2
@@ -311,7 +311,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(firehose_value_metric_rep_garden_health_check_failed{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
+          "expr": "max(firehose_value_metric_rep_garden_health_check_failed{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ bosh_deployment }}/{{ bosh_job_name }}/{{ bosh_job_ip }}",

--- a/jobs/cloudfoundry_dashboards/templates/cf_doppler_server.json
+++ b/jobs/cloudfoundry_dashboards/templates/cf_doppler_server.json
@@ -112,7 +112,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(firehose_value_metric_doppler_server_message_router_number_of_container_metric_sinks{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_doppler_server_message_router_number_of_container_metric_sinks{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Container Metric",
@@ -120,7 +120,7 @@
           "step": 2
         },
         {
-          "expr": "sum(avg(firehose_value_metric_doppler_server_message_router_number_of_dump_sinks{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_doppler_server_message_router_number_of_dump_sinks{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Dump",
@@ -128,21 +128,21 @@
           "step": 2
         },
         {
-          "expr": "sum(avg(firehose_value_metric_doppler_server_message_router_number_of_firehose_sinks{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_doppler_server_message_router_number_of_firehose_sinks{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "Firehose",
           "refId": "C",
           "step": 2
         },
         {
-          "expr": "sum(avg(firehose_value_metric_doppler_server_message_router_number_of_syslog_sinks{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_doppler_server_message_router_number_of_syslog_sinks{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "Syslog",
           "refId": "D",
           "step": 2
         },
         {
-          "expr": "sum(avg(firehose_value_metric_doppler_server_message_router_number_of_websocket_sinks{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_doppler_server_message_router_number_of_websocket_sinks{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Websocket",
@@ -230,7 +230,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(firehose_counter_event_doppler_server_dropsonde_unmarshaller_container_metric_received_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_doppler_server_dropsonde_unmarshaller_container_metric_received_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Container Metric",
@@ -238,7 +238,7 @@
           "step": 2
         },
         {
-          "expr": "sum(avg(firehose_counter_event_doppler_server_dropsonde_unmarshaller_counter_event_received_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_doppler_server_dropsonde_unmarshaller_counter_event_received_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Counter Event",
@@ -246,21 +246,21 @@
           "step": 2
         },
         {
-          "expr": "sum(avg(firehose_counter_event_doppler_server_dropsonde_unmarshaller_http_start_stop_received_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_doppler_server_dropsonde_unmarshaller_http_start_stop_received_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "HttpStartStop",
           "refId": "C",
           "step": 2
         },
         {
-          "expr": "sum(avg(firehose_counter_event_doppler_server_dropsonde_unmarshaller_log_message_total_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_doppler_server_dropsonde_unmarshaller_log_message_total_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "Log Message",
           "refId": "D",
           "step": 2
         },
         {
-          "expr": "sum(avg(firehose_counter_event_doppler_server_dropsonde_unmarshaller_value_metric_received_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_doppler_server_dropsonde_unmarshaller_value_metric_received_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Value Metric",
@@ -268,7 +268,7 @@
           "step": 2
         },
         {
-          "expr": "sum(avg(firehose_counter_event_doppler_server_dropsonde_unmarshaller_error_received_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_doppler_server_dropsonde_unmarshaller_error_received_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Error",
@@ -356,7 +356,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(firehose_counter_event_doppler_server_listeners_total_received_message_count_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_doppler_server_listeners_total_received_message_count_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "Messages",
           "refId": "A",
@@ -441,7 +441,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(firehose_counter_event_doppler_server_listeners_total_received_byte_count_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_doppler_server_listeners_total_received_byte_count_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Bytes",
@@ -525,7 +525,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(firehose_counter_event_doppler_server_dropsonde_unmarshaller_unmarshal_errors{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_doppler_server_dropsonde_unmarshaller_unmarshal_errors{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "Errors",
           "refId": "A",
@@ -607,14 +607,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(firehose_counter_event_doppler_server_truncating_buffer_total_dropped_messages{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_doppler_server_truncating_buffer_total_dropped_messages{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "Messages",
           "refId": "A",
           "step": 4
         },
         {
-          "expr": "sum(avg(firehose_counter_event_doppler_server_doppler_shed_envelopes_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_doppler_server_doppler_shed_envelopes_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "Messages",
           "refId": "B",

--- a/jobs/cloudfoundry_dashboards/templates/cf_doppler_server_v2.json
+++ b/jobs/cloudfoundry_dashboards/templates/cf_doppler_server_v2.json
@@ -112,7 +112,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(firehose_value_metric_loggregator_doppler_container_metric_sinks{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_loggregator_doppler_container_metric_sinks{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -121,7 +121,7 @@
           "step": 2
         },
         {
-          "expr": "sum(avg(firehose_value_metric_loggregator_doppler_dump_sinks{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_loggregator_doppler_dump_sinks{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -211,7 +211,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(firehose_counter_event_loggregator_doppler_ingress_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_loggregator_doppler_ingress_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Messages",
@@ -299,7 +299,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_value_metric_loggregator_doppler_subscriptions{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
+          "expr": "avg(firehose_value_metric_loggregator_doppler_subscriptions{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "subscriptions",
@@ -387,7 +387,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(max(firehose_counter_event_loggregator_doppler_dropped_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by (bosh_job_id)) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
+          "expr": "sum(max(firehose_counter_event_loggregator_doppler_dropped_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by (bosh_job_id)) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Dropped Messages",
@@ -476,7 +476,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(max(firehose_counter_event_loggregator_doppler_dropped_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by (bosh_job_ip))/sum(max(firehose_counter_event_loggregator_doppler_ingress_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by (bosh_job_ip))",
+          "expr": "sum(max(firehose_counter_event_loggregator_doppler_dropped_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by (bosh_job_ip))/sum(max(firehose_counter_event_loggregator_doppler_ingress_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by (bosh_job_ip))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Dropped Messages (%)",

--- a/jobs/cloudfoundry_dashboards/templates/cf_etcd.json
+++ b/jobs/cloudfoundry_dashboards/templates/cf_etcd.json
@@ -140,7 +140,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "avg(count(firehose_value_metric_etcd_is_leader{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"} == 1) by(instance, bosh_job_ip)) by(bosh_job_ip)",
+          "expr": "avg(count(firehose_value_metric_etcd_is_leader{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"} == 1) by(instance, bosh_job_ip)) by(bosh_job_ip)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ bosh_job_ip }}",
@@ -227,7 +227,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(avg(firehose_value_metric_etcd_followers{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_etcd_followers{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "",
           "metric": "",
@@ -290,7 +290,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_value_metric_etcd_watchers{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
+          "expr": "avg(firehose_value_metric_etcd_watchers{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ bosh_deployment }}/{{ bosh_job_name }}/{{ bosh_job_ip }}",
@@ -378,7 +378,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_value_metric_etcd_raft_term{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
+          "expr": "avg(firehose_value_metric_etcd_raft_term{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ bosh_deployment }}/{{ bosh_job_name }}/{{ bosh_job_ip }}",
@@ -465,7 +465,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_value_metric_etcd_raft_index{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
+          "expr": "avg(firehose_value_metric_etcd_raft_index{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ bosh_deployment }}/{{ bosh_job_name }}/{{ bosh_job_ip }}",
@@ -553,7 +553,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_value_metric_etcd_receiving_bandwidth_rate{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
+          "expr": "avg(firehose_value_metric_etcd_receiving_bandwidth_rate{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Receiving ({{ bosh_deployment }}/{{ bosh_job_name }}/{{ bosh_job_ip }})",
@@ -561,7 +561,7 @@
           "step": 4
         },
         {
-          "expr": "avg(firehose_value_metric_etcd_sending_bandwidth_rate{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
+          "expr": "avg(firehose_value_metric_etcd_sending_bandwidth_rate{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Sending ({{ bosh_deployment }}/{{ bosh_job_name }}/{{ bosh_job_ip }})",
@@ -649,14 +649,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_value_metric_etcd_receiving_request_rate{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
+          "expr": "avg(firehose_value_metric_etcd_receiving_request_rate{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
           "intervalFactor": 2,
           "legendFormat": "Receiving ({{ bosh_deployment }}/{{ bosh_job_name }}/{{ bosh_job_ip }})",
           "refId": "A",
           "step": 4
         },
         {
-          "expr": "avg(firehose_value_metric_etcd_sending_request_rate{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
+          "expr": "avg(firehose_value_metric_etcd_sending_request_rate{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Sending ({{ bosh_deployment }}/{{ bosh_job_name }}/{{ bosh_job_ip }})",
@@ -742,7 +742,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_value_metric_etcd_latency{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
+          "expr": "avg(firehose_value_metric_etcd_latency{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ bosh_deployment }}/{{ bosh_job_name }}/{{ bosh_job_ip }}",
@@ -829,7 +829,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(firehose_value_metric_etcd_received_append_requests{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}[5m])) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
+          "expr": "avg(rate(firehose_value_metric_etcd_received_append_requests{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}[5m])) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Received ({{ bosh_deployment }}/{{ bosh_job_name }}/{{ bosh_job_ip }})",
@@ -838,7 +838,7 @@
           "step": 4
         },
         {
-          "expr": "avg(rate(firehose_value_metric_etcd_sent_append_requests{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}[5m])) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
+          "expr": "avg(rate(firehose_value_metric_etcd_sent_append_requests{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}[5m])) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Sent ({{ bosh_deployment }}/{{ bosh_job_name }}/{{ bosh_job_ip }})",

--- a/jobs/cloudfoundry_dashboards/templates/cf_etcd_operations.json
+++ b/jobs/cloudfoundry_dashboards/templates/cf_etcd_operations.json
@@ -110,7 +110,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(firehose_value_metric_etcd_sets_fail{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}[5m])) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
+          "expr": "avg(rate(firehose_value_metric_etcd_sets_fail{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}[5m])) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Fail ({{ bosh_deployment }}/{{ bosh_job_name }}/{{ bosh_job_ip }})",
@@ -118,7 +118,7 @@
           "step": 4
         },
         {
-          "expr": "avg(rate(firehose_value_metric_etcd_sets_success{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}[5m])) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
+          "expr": "avg(rate(firehose_value_metric_etcd_sets_success{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}[5m])) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Success ({{ bosh_deployment }}/{{ bosh_job_name }}/{{ bosh_job_ip }})",
@@ -204,7 +204,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(firehose_value_metric_etcd_gets_fail{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}[5m])) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
+          "expr": "avg(rate(firehose_value_metric_etcd_gets_fail{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}[5m])) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Fail ({{ bosh_deployment }}/{{ bosh_job_name }}/{{ bosh_job_ip }})",
@@ -213,7 +213,7 @@
           "step": 4
         },
         {
-          "expr": "avg(rate(firehose_value_metric_etcd_gets_success{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}[5m])) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
+          "expr": "avg(rate(firehose_value_metric_etcd_gets_success{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}[5m])) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Success ({{ bosh_deployment }}/{{ bosh_job_name }}/{{ bosh_job_ip }})",
@@ -299,7 +299,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(firehose_value_metric_etcd_create_fail{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}[5m])) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
+          "expr": "avg(rate(firehose_value_metric_etcd_create_fail{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}[5m])) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Fail ({{ bosh_deployment }}/{{ bosh_job_name }}/{{ bosh_job_ip }})",
@@ -308,7 +308,7 @@
           "step": 10
         },
         {
-          "expr": "avg(rate(firehose_value_metric_etcd_create_success{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}[5m])) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
+          "expr": "avg(rate(firehose_value_metric_etcd_create_success{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}[5m])) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Success ({{ bosh_deployment }}/{{ bosh_job_name }}/{{ bosh_job_ip }})",
@@ -394,14 +394,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(firehose_value_metric_etcd_update_fail{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}[5m])) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
+          "expr": "avg(rate(firehose_value_metric_etcd_update_fail{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}[5m])) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
           "intervalFactor": 2,
           "legendFormat": "Fail ({{ bosh_deployment }}/{{ bosh_job_name }}/{{ bosh_job_ip }})",
           "refId": "A",
           "step": 10
         },
         {
-          "expr": "avg(rate(firehose_value_metric_etcd_update_success{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}[5m])) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
+          "expr": "avg(rate(firehose_value_metric_etcd_update_success{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}[5m])) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Success ({{ bosh_deployment }}/{{ bosh_job_name }}/{{ bosh_job_ip }})",
@@ -487,14 +487,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(firehose_value_metric_etcd_delete_fail{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}[5m])) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
+          "expr": "avg(rate(firehose_value_metric_etcd_delete_fail{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}[5m])) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
           "intervalFactor": 2,
           "legendFormat": "Fail ({{ bosh_deployment }}/{{ bosh_job_name }}/{{ bosh_job_ip }})",
           "refId": "A",
           "step": 10
         },
         {
-          "expr": "avg(rate(firehose_value_metric_etcd_delete_success{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}[5m])) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
+          "expr": "avg(rate(firehose_value_metric_etcd_delete_success{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}[5m])) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Success ({{ bosh_deployment }}/{{ bosh_job_name }}/{{ bosh_job_ip }})",
@@ -580,14 +580,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(firehose_value_metric_etcd_compare_and_delete_fail{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}[5m])) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
+          "expr": "avg(rate(firehose_value_metric_etcd_compare_and_delete_fail{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}[5m])) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
           "intervalFactor": 2,
           "legendFormat": "Fail ({{ bosh_deployment }}/{{ bosh_job_name }}/{{ bosh_job_ip }})",
           "refId": "A",
           "step": 4
         },
         {
-          "expr": "avg(rate(firehose_value_metric_etcd_compare_and_delete_success{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}[5m])) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
+          "expr": "avg(rate(firehose_value_metric_etcd_compare_and_delete_success{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}[5m])) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Success ({{ bosh_deployment }}/{{ bosh_job_name }}/{{ bosh_job_ip }})",
@@ -673,14 +673,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(firehose_value_metric_etcd_compare_and_swap_fail{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}[5m])) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
+          "expr": "avg(rate(firehose_value_metric_etcd_compare_and_swap_fail{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}[5m])) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
           "intervalFactor": 2,
           "legendFormat": "Fail ({{ bosh_deployment }}/{{ bosh_job_name }}/{{ bosh_job_ip }})",
           "refId": "A",
           "step": 4
         },
         {
-          "expr": "avg(rate(firehose_value_metric_etcd_compare_and_swap_success{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}[5m])) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
+          "expr": "avg(rate(firehose_value_metric_etcd_compare_and_swap_success{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}[5m])) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Success ({{ bosh_deployment }}/{{ bosh_job_name }}/{{ bosh_job_ip }})",

--- a/jobs/cloudfoundry_dashboards/templates/cf_garden_linux.json
+++ b/jobs/cloudfoundry_dashboards/templates/cf_garden_linux.json
@@ -112,7 +112,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_value_metric_garden_linux_backing_stores{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",bosh_job_name=~\"$bosh_job_name\", bosh_job_id=~\"$bosh_job_id\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
+          "expr": "avg(firehose_value_metric_garden_linux_backing_stores{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",bosh_job_name=~\"$bosh_job_name\", bosh_job_id=~\"$bosh_job_id\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ bosh_deployment }}/{{ bosh_job_name }}/{{ bosh_job_ip }}",
@@ -198,7 +198,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_value_metric_garden_linux_loop_devices{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",bosh_job_name=~\"$bosh_job_name\", bosh_job_id=~\"$bosh_job_id\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
+          "expr": "avg(firehose_value_metric_garden_linux_loop_devices{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",bosh_job_name=~\"$bosh_job_name\", bosh_job_id=~\"$bosh_job_id\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ bosh_deployment }}/{{ bosh_job_name }}/{{ bosh_job_ip }}",
@@ -284,7 +284,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_value_metric_garden_linux_depot_dirs{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",bosh_job_name=~\"$bosh_job_name\", bosh_job_id=~\"$bosh_job_id\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
+          "expr": "avg(firehose_value_metric_garden_linux_depot_dirs{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",bosh_job_name=~\"$bosh_job_name\", bosh_job_id=~\"$bosh_job_id\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{ bosh_deployment }}/{{ bosh_job_name }}/{{ bosh_job_ip }}",
@@ -390,7 +390,7 @@
         "multi": false,
         "name": "bosh_job_name",
         "options": [],
-        "query": "label_values(firehose_value_metric_garden_linux_num_cpus{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}, bosh_job_name)",
+        "query": "label_values(firehose_value_metric_garden_linux_num_cpus{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}\"}, bosh_job_name)",
         "refresh": 1,
         "regex": "",
         "sort": 1,
@@ -410,7 +410,7 @@
         "multi": false,
         "name": "bosh_job_id",
         "options": [],
-        "query": "label_values(firehose_value_metric_garden_linux_num_cpus{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",bosh_job_name=~\"$bosh_job_name\"}, bosh_job_id)",
+        "query": "label_values(firehose_value_metric_garden_linux_num_cpus{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}\",bosh_job_name=~\"$bosh_job_name\"}, bosh_job_id)",
         "refresh": 1,
         "regex": "",
         "sort": 1,

--- a/jobs/cloudfoundry_dashboards/templates/cf_kpis.json
+++ b/jobs/cloudfoundry_dashboards/templates/cf_kpis.json
@@ -138,7 +138,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "count(min(firehose_value_metric_rep_garden_health_check_failed{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip) == 1)",
+          "expr": "count(min(firehose_value_metric_rep_garden_health_check_failed{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip) == 1)",
           "intervalFactor": 2,
           "refId": "A",
           "step": 60
@@ -219,7 +219,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "max(firehose_value_metric_bbs_lr_ps_missing{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"})",
+          "expr": "max(firehose_value_metric_bbs_lr_ps_missing{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"})",
           "intervalFactor": 2,
           "metric": "firehose_value_metric_bbs_lr_ps_missing",
           "refId": "A",
@@ -302,7 +302,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "min(firehose_value_metric_bbs_domain_cf_apps{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"})",
+          "expr": "min(firehose_value_metric_bbs_domain_cf_apps{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"})",
           "hide": false,
           "intervalFactor": 2,
           "legendFormat": "",
@@ -397,7 +397,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "min(firehose_value_metric_bbs_domain_cf_tasks{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"})",
+          "expr": "min(firehose_value_metric_bbs_domain_cf_tasks{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"})",
           "hide": false,
           "intervalFactor": 2,
           "legendFormat": "",
@@ -582,7 +582,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "min(firehose_value_metric_route_emitter_consul_down_mode{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"})",
+          "expr": "min(firehose_value_metric_route_emitter_consul_down_mode{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"})",
           "intervalFactor": 2,
           "legendFormat": "",
           "metric": "firehose_value_metric_route_emitter_consul_down_mode",
@@ -675,7 +675,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "avg(avg_over_time(firehose_value_metric_bbs_lr_ps_running{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}[1d]))",
+          "expr": "avg(avg_over_time(firehose_value_metric_bbs_lr_ps_running{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}[1d]))",
           "intervalFactor": 2,
           "legendFormat": "",
           "metric": "firehose_value_metric_bbs_lr_ps_running",
@@ -759,7 +759,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "avg(firehose_value_metric_gorouter_total_routes{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"})",
+          "expr": "avg(firehose_value_metric_gorouter_total_routes{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"})",
           "intervalFactor": 2,
           "legendFormat": "Routes",
           "metric": "firehose_value_metric_gorouter_total_routes",
@@ -843,7 +843,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(avg(firehose_value_metric_uaa_audit_service_user_authentication_failure_count{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_uaa_audit_service_user_authentication_failure_count{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "refId": "A",
           "step": 60
@@ -908,7 +908,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "min(avg(firehose_value_metric_rep_capacity_remaining_memory{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "min(avg(firehose_value_metric_rep_capacity_remaining_memory{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Cell with Least Available Memory",
@@ -917,7 +917,7 @@
           "step": 10
         },
         {
-          "expr": "max(avg(firehose_value_metric_rep_capacity_remaining_memory{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "max(avg(firehose_value_metric_rep_capacity_remaining_memory{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Cell with Most Available Memory",
@@ -926,7 +926,7 @@
           "step": 10
         },
         {
-          "expr": "sum(avg(firehose_value_metric_rep_capacity_remaining_memory{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_rep_capacity_remaining_memory{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Total Available Available Memory",
@@ -1011,7 +1011,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "min(avg(firehose_value_metric_rep_capacity_remaining_disk{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "min(avg(firehose_value_metric_rep_capacity_remaining_disk{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Cell with Least Available Disk",
@@ -1020,7 +1020,7 @@
           "step": 10
         },
         {
-          "expr": "max(avg(firehose_value_metric_rep_capacity_remaining_disk{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "max(avg(firehose_value_metric_rep_capacity_remaining_disk{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Cell with Most Available Disk",
@@ -1029,7 +1029,7 @@
           "step": 10
         },
         {
-          "expr": "sum(avg(firehose_value_metric_rep_capacity_remaining_disk{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_rep_capacity_remaining_disk{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Total Available Disk",
@@ -1114,7 +1114,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "min(avg(firehose_value_metric_rep_capacity_remaining_containers{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "min(avg(firehose_value_metric_rep_capacity_remaining_containers{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Cell with Least Available Containers",
@@ -1123,7 +1123,7 @@
           "step": 10
         },
         {
-          "expr": "max(avg(firehose_value_metric_rep_capacity_remaining_containers{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "max(avg(firehose_value_metric_rep_capacity_remaining_containers{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Cell with Most Available Containers",
@@ -1132,7 +1132,7 @@
           "step": 10
         },
         {
-          "expr": "sum(avg(firehose_value_metric_rep_capacity_remaining_containers{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_rep_capacity_remaining_containers{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Total Available Containers",
@@ -1215,7 +1215,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(rate(firehose_counter_event_bbs_request_count_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}[5m]))",
+          "expr": "max(rate(firehose_counter_event_bbs_request_count_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}[5m]))",
           "intervalFactor": 2,
           "legendFormat": "Req/Sec",
           "refId": "A",
@@ -1298,7 +1298,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(firehose_value_metric_bbs_request_latency{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"})",
+          "expr": "max(firehose_value_metric_bbs_request_latency{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"})",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Latency",
@@ -1382,7 +1382,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(firehose_value_metric_bbs_convergence_lrp_duration{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"})",
+          "expr": "max(firehose_value_metric_bbs_convergence_lrp_duration{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"})",
           "hide": false,
           "interval": "",
           "intervalFactor": 2,
@@ -1392,7 +1392,7 @@
           "step": 10
         },
         {
-          "expr": "max(firehose_value_metric_bbs_convergence_task_duration{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"})",
+          "expr": "max(firehose_value_metric_bbs_convergence_task_duration{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"})",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Tasks",
@@ -1475,7 +1475,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(rate(firehose_counter_event_gorouter_total_requests_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}[5m]))",
+          "expr": "max(rate(firehose_counter_event_gorouter_total_requests_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}[5m]))",
           "interval": "5m",
           "intervalFactor": 2,
           "legendFormat": "Req/Sec",
@@ -1559,7 +1559,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(firehose_value_metric_gorouter_latency{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"})",
+          "expr": "max(firehose_value_metric_gorouter_latency{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"})",
           "interval": "5m",
           "intervalFactor": 2,
           "legendFormat": "Latency",
@@ -1643,7 +1643,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(rate(firehose_counter_event_gorouter_bad_gateways_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}[5m]))",
+          "expr": "max(rate(firehose_counter_event_gorouter_bad_gateways_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}[5m]))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Resp/sec",
@@ -1727,7 +1727,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(rate(firehose_value_metric_cc_requests_completed{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}[5m]))",
+          "expr": "max(rate(firehose_value_metric_cc_requests_completed{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}[5m]))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Req/sec",
@@ -1810,7 +1810,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(firehose_value_metric_cc_job_queue_length_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"})",
+          "expr": "max(firehose_value_metric_cc_job_queue_length_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"})",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Length",
@@ -1893,7 +1893,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(rate(firehose_value_metric_cc_http_status_5_xx{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}[5m]))",
+          "expr": "max(rate(firehose_value_metric_cc_http_status_5_xx{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}[5m]))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "5xx resp/sec",
@@ -1976,7 +1976,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(rate(firehose_counter_event_auctioneer_auctioneer_lrp_auctions_started_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}[5m]))",
+          "expr": "max(rate(firehose_counter_event_auctioneer_auctioneer_lrp_auctions_started_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}[5m]))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "LRPs",
@@ -1985,7 +1985,7 @@
           "step": 10
         },
         {
-          "expr": "max(rate(firehose_counter_event_auctioneer_auctioneer_task_auctions_started_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}[5m]))",
+          "expr": "max(rate(firehose_counter_event_auctioneer_auctioneer_task_auctions_started_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}[5m]))",
           "hide": false,
           "interval": "",
           "intervalFactor": 2,
@@ -2070,28 +2070,28 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(firehose_counter_event_auctioneer_auctioneer_lrp_auctions_started_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_auctioneer_auctioneer_lrp_auctions_started_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "Started LPRs",
           "refId": "A",
           "step": 10
         },
         {
-          "expr": "sum(avg(firehose_counter_event_auctioneer_auctioneer_lrp_auctions_failed_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_auctioneer_auctioneer_lrp_auctions_failed_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "Failed LRPs",
           "refId": "B",
           "step": 10
         },
         {
-          "expr": "sum(avg(firehose_counter_event_auctioneer_auctioneer_task_auctions_started_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_auctioneer_auctioneer_task_auctions_started_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "Started Tasks",
           "refId": "C",
           "step": 10
         },
         {
-          "expr": "sum(avg(firehose_counter_event_auctioneer_auctioneer_task_auctions_failed_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_auctioneer_auctioneer_task_auctions_failed_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "Failed Tasks",
           "refId": "D",
@@ -2173,7 +2173,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(firehose_value_metric_auctioneer_auctioneer_fetch_states_duration{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"})",
+          "expr": "max(firehose_value_metric_auctioneer_auctioneer_fetch_states_duration{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"})",
           "intervalFactor": 2,
           "legendFormat": "Duration",
           "refId": "A",
@@ -2255,7 +2255,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(max_over_time(firehose_value_metric_nsync_bulker_desired_lrp_sync_duration{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}[5m]))",
+          "expr": "max(max_over_time(firehose_value_metric_nsync_bulker_desired_lrp_sync_duration{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}[5m]))",
           "hide": false,
           "interval": "",
           "intervalFactor": 2,
@@ -2339,7 +2339,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(rate(firehose_value_metric_bbs_lr_ps_desired{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}[30m]))",
+          "expr": "max(rate(firehose_value_metric_bbs_lr_ps_desired{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}[30m]))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "LRPs Desired",
@@ -2348,7 +2348,7 @@
           "step": 10
         },
         {
-          "expr": "max(rate(firehose_value_metric_bbs_lr_ps_running{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}[30m]))",
+          "expr": "max(rate(firehose_value_metric_bbs_lr_ps_running{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}[30m]))",
           "hide": false,
           "interval": "",
           "intervalFactor": 2,
@@ -2434,7 +2434,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(avg_over_time(firehose_counter_event_stager_staging_requests_failed_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}[1h]))",
+          "expr": "max(avg_over_time(firehose_counter_event_stager_staging_requests_failed_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}[1h]))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "1hr Avg Failed Requests",
@@ -2523,7 +2523,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(rate(firehose_counter_event_doppler_server_listeners_total_received_message_count_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}[5m]))",
+          "expr": "max(rate(firehose_counter_event_doppler_server_listeners_total_received_message_count_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}[5m]))",
           "hide": false,
           "interval": "",
           "intervalFactor": 2,
@@ -2533,7 +2533,7 @@
           "step": 10
         },
         {
-          "expr": "max(rate(firehose_counter_event_doppler_server_truncating_buffer_total_dropped_messages_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}[5m]))",
+          "expr": "max(rate(firehose_counter_event_doppler_server_truncating_buffer_total_dropped_messages_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}[5m]))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Dropped",
@@ -2617,14 +2617,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(rate(firehose_counter_event_metron_agent_dropsonde_marshaller_sent_envelopes_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}[5m]))",
+          "expr": "max(rate(firehose_counter_event_metron_agent_dropsonde_marshaller_sent_envelopes_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}[5m]))",
           "intervalFactor": 2,
           "legendFormat": "Marshalled",
           "refId": "A",
           "step": 10
         },
         {
-          "expr": "max(rate(firehose_counter_event_metron_agent_dropsonde_unmarshaller_received_envelopes_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}[5m]))",
+          "expr": "max(rate(firehose_counter_event_metron_agent_dropsonde_unmarshaller_received_envelopes_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}[5m]))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Unmarshalled",
@@ -2707,28 +2707,28 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(rate(firehose_counter_event_metron_agent_udp_sent_message_count_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}[5m]))",
+          "expr": "max(rate(firehose_counter_event_metron_agent_udp_sent_message_count_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}[5m]))",
           "intervalFactor": 2,
           "legendFormat": "UDP",
           "refId": "A",
           "step": 10
         },
         {
-          "expr": "max(rate(firehose_counter_event_metron_agent_tcp_sent_message_count_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}[5m]))",
+          "expr": "max(rate(firehose_counter_event_metron_agent_tcp_sent_message_count_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}[5m]))",
           "intervalFactor": 2,
           "legendFormat": "TCP",
           "refId": "B",
           "step": 10
         },
         {
-          "expr": "max(rate(firehose_counter_event_metron_agent_tls_sent_message_count_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}[5m]))",
+          "expr": "max(rate(firehose_counter_event_metron_agent_tls_sent_message_count_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}[5m]))",
           "intervalFactor": 2,
           "legendFormat": "TLS",
           "refId": "C",
           "step": 10
         },
         {
-          "expr": "max(rate(firehose_counter_event_metron_agent_grpc_sent_message_count_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}[5m]))",
+          "expr": "max(rate(firehose_counter_event_metron_agent_grpc_sent_message_count_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}[5m]))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "GRPC",

--- a/jobs/cloudfoundry_dashboards/templates/cf_lrps_tasks.json
+++ b/jobs/cloudfoundry_dashboards/templates/cf_lrps_tasks.json
@@ -114,42 +114,42 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(firehose_value_metric_bbs_lr_ps_desired{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_bbs_lr_ps_desired{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "Desired",
           "refId": "A",
           "step": 2
         },
         {
-          "expr": "sum(avg(firehose_value_metric_bbs_lr_ps_running{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_bbs_lr_ps_running{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "Running",
           "refId": "B",
           "step": 2
         },
         {
-          "expr": "sum(avg(firehose_value_metric_bbs_lr_ps_extra{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_bbs_lr_ps_extra{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "Extra",
           "refId": "C",
           "step": 2
         },
         {
-          "expr": "sum(avg(firehose_value_metric_bbs_lr_ps_missing{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_bbs_lr_ps_missing{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "Missing",
           "refId": "D",
           "step": 2
         },
         {
-          "expr": "sum(avg(firehose_value_metric_bbs_lr_ps_claimed{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_bbs_lr_ps_claimed{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "Claimed",
           "refId": "E",
           "step": 2
         },
         {
-          "expr": "sum(avg(firehose_value_metric_bbs_lr_ps_unclaimed{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_bbs_lr_ps_unclaimed{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Unclaimed",
@@ -239,7 +239,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(firehose_value_metric_bbs_tasks_pending{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_bbs_tasks_pending{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Pending",
@@ -247,21 +247,21 @@
           "step": 2
         },
         {
-          "expr": "sum(avg(firehose_value_metric_bbs_tasks_resolving{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_bbs_tasks_resolving{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "Resolving",
           "refId": "B",
           "step": 2
         },
         {
-          "expr": "sum(avg(firehose_value_metric_bbs_tasks_running{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_bbs_tasks_running{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "Running",
           "refId": "C",
           "step": 2
         },
         {
-          "expr": "sum(avg(firehose_value_metric_bbs_tasks_completed{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_bbs_tasks_completed{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "Completed",
           "refId": "D",
@@ -349,14 +349,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(firehose_value_metric_bbs_crashed_actual_lr_ps{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_bbs_crashed_actual_lr_ps{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "Actual",
           "refId": "A",
           "step": 2
         },
         {
-          "expr": "sum(avg(firehose_value_metric_bbs_crashing_desired_lr_ps{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_bbs_crashing_desired_lr_ps{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "Desired",
           "refId": "B",
@@ -441,7 +441,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_value_metric_nsync_bulker_desired_lrp_sync_duration{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) ",
+          "expr": "avg(firehose_value_metric_nsync_bulker_desired_lrp_sync_duration{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) ",
           "intervalFactor": 2,
           "legendFormat": "Duration",
           "refId": "A",

--- a/jobs/cloudfoundry_dashboards/templates/cf_metron_agent.json
+++ b/jobs/cloudfoundry_dashboards/templates/cf_metron_agent.json
@@ -112,7 +112,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(firehose_counter_event_metron_agent_dropsonde_marshaller_sent_envelopes_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_metron_agent_dropsonde_marshaller_sent_envelopes_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Sent (Marshaller)",
@@ -120,7 +120,7 @@
           "step": 2
         },
         {
-          "expr": "sum(avg(firehose_counter_event_metron_agent_dropsonde_unmarshaller_received_envelopes_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_metron_agent_dropsonde_unmarshaller_received_envelopes_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Received (Unmarshaller)",
@@ -208,7 +208,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(firehose_counter_event_metron_agent_dropsonde_unmarshaller_container_metric_received_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_metron_agent_dropsonde_unmarshaller_container_metric_received_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Container Metric",
@@ -216,7 +216,7 @@
           "step": 2
         },
         {
-          "expr": "sum(avg(firehose_counter_event_metron_agent_dropsonde_unmarshaller_counter_event_received_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_metron_agent_dropsonde_unmarshaller_counter_event_received_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Counter Event",
@@ -224,21 +224,21 @@
           "step": 2
         },
         {
-          "expr": "sum(avg(firehose_counter_event_metron_agent_dropsonde_unmarshaller_http_start_stop_received_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_metron_agent_dropsonde_unmarshaller_http_start_stop_received_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "HttpStartStop",
           "refId": "C",
           "step": 2
         },
         {
-          "expr": "sum(avg(firehose_counter_event_metron_agent_dropsonde_unmarshaller_log_message_total_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_metron_agent_dropsonde_unmarshaller_log_message_total_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "Log Message",
           "refId": "D",
           "step": 2
         },
         {
-          "expr": "sum(avg(firehose_counter_event_metron_agent_dropsonde_unmarshaller_value_metric_received_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_metron_agent_dropsonde_unmarshaller_value_metric_received_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Value Metric",
@@ -246,7 +246,7 @@
           "step": 2
         },
         {
-          "expr": "sum(avg(firehose_counter_event_metron_agent_dropsonde_unmarshaller_error_received_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_metron_agent_dropsonde_unmarshaller_error_received_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "Error",
           "refId": "F",
@@ -333,7 +333,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(firehose_counter_event_metron_agent_dropsonde_agent_listener_received_message_count_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_metron_agent_dropsonde_agent_listener_received_message_count_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "Messages",
           "refId": "A",
@@ -418,7 +418,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(firehose_counter_event_metron_agent_dropsonde_agent_listener_received_byte_count_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_metron_agent_dropsonde_agent_listener_received_byte_count_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Bytes",

--- a/jobs/cloudfoundry_dashboards/templates/cf_metron_agent_doppler.json
+++ b/jobs/cloudfoundry_dashboards/templates/cf_metron_agent_doppler.json
@@ -112,7 +112,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(firehose_counter_event_metron_agent_udp_sent_message_count_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_metron_agent_udp_sent_message_count_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "UDP",
@@ -120,7 +120,7 @@
           "step": 2
         },
         {
-          "expr": "sum(avg(firehose_counter_event_metron_agent_tcp_sent_message_count_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_metron_agent_tcp_sent_message_count_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "TCP",
@@ -128,7 +128,7 @@
           "step": 2
         },
         {
-          "expr": "sum(avg(firehose_counter_event_metron_agent_tls_sent_message_count_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_metron_agent_tls_sent_message_count_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "TLS",
@@ -136,7 +136,7 @@
           "step": 2
         },
         {
-          "expr": "sum(avg(firehose_counter_event_metron_agent_grpc_sent_message_count_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_metron_agent_grpc_sent_message_count_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "GRPC",
           "refId": "D",
@@ -223,7 +223,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(firehose_counter_event_metron_agent_udp_sent_byte_count_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_metron_agent_udp_sent_byte_count_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "UDP",
@@ -231,21 +231,21 @@
           "step": 2
         },
         {
-          "expr": "sum(avg(firehose_counter_event_metron_agent_tcp_sent_byte_count_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_metron_agent_tcp_sent_byte_count_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "TCP",
           "refId": "B",
           "step": 2
         },
         {
-          "expr": "sum(avg(firehose_counter_event_metron_agent_tls_sent_byte_count_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_metron_agent_tls_sent_byte_count_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "TLS",
           "refId": "C",
           "step": 2
         },
         {
-          "expr": "sum(avg(firehose_counter_event_metron_agent_grpc_sent_byte_count_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_metron_agent_grpc_sent_byte_count_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "GRPC",
           "refId": "D",
@@ -332,28 +332,28 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(firehose_counter_event_metron_agent_udp_send_error_count_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_metron_agent_udp_send_error_count_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "UDP",
           "refId": "A",
           "step": 2
         },
         {
-          "expr": "sum(avg(firehose_counter_event_metron_agent_tcp_send_error_count_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_metron_agent_tcp_send_error_count_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "TCP",
           "refId": "B",
           "step": 2
         },
         {
-          "expr": "sum(avg(firehose_counter_event_metron_agent_tls_send_error_count_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_metron_agent_tls_send_error_count_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "TLS",
           "refId": "C",
           "step": 2
         },
         {
-          "expr": "sum(avg(firehose_counter_event_metron_agent_grpc_send_error_count_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_metron_agent_grpc_send_error_count_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "GRPC",
           "refId": "D",

--- a/jobs/cloudfoundry_dashboards/templates/cf_metron_agent_v2.json
+++ b/jobs/cloudfoundry_dashboards/templates/cf_metron_agent_v2.json
@@ -112,7 +112,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(max(firehose_counter_event_loggregator_metron_egress_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(max(firehose_counter_event_loggregator_metron_egress_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -201,7 +201,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(firehose_counter_event_loggregator_metron_egress_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(environment, bosh_deployment, bosh_job_name)",
+          "expr": "max(firehose_counter_event_loggregator_metron_egress_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(environment, bosh_deployment, bosh_job_name)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{bosh_job_name}}",
@@ -289,7 +289,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(max(firehose_counter_event_loggregator_metron_ingress_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(max(firehose_counter_event_loggregator_metron_ingress_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Messages",

--- a/jobs/cloudfoundry_dashboards/templates/cf_organization_memory_quotas.json
+++ b/jobs/cloudfoundry_dashboards/templates/cf_organization_memory_quotas.json
@@ -113,7 +113,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "((sum(avg(cf_application_memory_mb{environment=~\"$environment\",deployment=~\"$bosh_deployment\"} * on (organization_name, application_id) cf_application_instances{environment=~\"$environment\",deployment=~\"$bosh_deployment\",state=\"STARTED\"}) by(organization_name, application_id)) by(organization_name) / on(organization_name) avg(cf_organization_total_memory_mb_quota{environment=~\"$environment\",deployment=~\"$bosh_deployment\"}) by(organization_name) > 0) * 100 > $quota_limit) * on (organization_name) group_left(quota_name) count(cf_organization_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\",quota_name=~\"$cf_quota_name\"}) by(organization_name, quota_name)",
+          "expr": "((sum(avg(cf_application_memory_mb{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\"} * on (organization_name, application_id) cf_application_instances{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\",state=\"STARTED\"}) by(organization_name, application_id)) by(organization_name) / on(organization_name) avg(cf_organization_total_memory_mb_quota{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(organization_name) > 0) * 100 > $quota_limit) * on (organization_name) group_left(quota_name) count(cf_organization_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}\",quota_name=~\"$cf_quota_name\"}) by(organization_name, quota_name)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ organization_name }} ({{ quota_name }})",
@@ -199,7 +199,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(cf_application_memory_mb{environment=~\"$environment\",deployment=~\"$bosh_deployment\"} * on (organization_name, application_id) cf_application_instances{environment=~\"$environment\",deployment=~\"$bosh_deployment\",state=\"STARTED\"}) by(organization_name, application_id)) by(organization_name) * on (organization_name) group_left(quota_name) count(cf_organization_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\",quota_name=~\"$cf_quota_name\"}) by(organization_name, quota_name)",
+          "expr": "sum(avg(cf_application_memory_mb{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\"} * on (organization_name, application_id) cf_application_instances{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\",state=\"STARTED\"}) by(organization_name, application_id)) by(organization_name) * on (organization_name) group_left(quota_name) count(cf_organization_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}\",quota_name=~\"$cf_quota_name\"}) by(organization_name, quota_name)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ organization_name }} ({{ quota_name }})",
@@ -304,7 +304,7 @@
         "multi": true,
         "name": "cf_quota_name",
         "options": [],
-        "query": "label_values(cf_organization_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\"}, quota_name)",
+        "query": "label_values(cf_organization_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}\"}, quota_name)",
         "refresh": 1,
         "regex": "",
         "sort": 1,
@@ -324,7 +324,7 @@
         "multi": true,
         "name": "cf_organization_name",
         "options": [],
-        "query": "label_values(cf_organization_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\"}, organization_name)",
+        "query": "label_values(cf_organization_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}\"}, organization_name)",
         "refresh": 1,
         "regex": "",
         "sort": 1,

--- a/jobs/cloudfoundry_dashboards/templates/cf_organization_summary.json
+++ b/jobs/cloudfoundry_dashboards/templates/cf_organization_summary.json
@@ -115,7 +115,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(cf_application_instances{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_name=~\"$cf_organization_name\",state=\"STARTED\"}) by(application_id))",
+          "expr": "sum(avg(cf_application_instances{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\",organization_name=~\"$cf_organization_name\",state=\"STARTED\"}) by(application_id))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Used",
@@ -123,7 +123,7 @@
           "step": 4
         },
         {
-          "expr": "avg(cf_organization_total_app_instances_quota{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_name=~\"$cf_organization_name\"})",
+          "expr": "avg(cf_organization_total_app_instances_quota{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\",organization_name=~\"$cf_organization_name\"})",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Quota",
@@ -200,7 +200,7 @@
       "strokeWidth": 1,
       "targets": [
         {
-          "expr": "sum(avg(cf_application_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_name=~\"$cf_organization_name\"}) by(application_id, state)) by(state) ",
+          "expr": "sum(avg(cf_application_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\",organization_name=~\"$cf_organization_name\"}) by(application_id, state)) by(state) ",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ state }}",
@@ -252,14 +252,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(cf_application_memory_mb{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_name=~\"$cf_organization_name\"} * on (application_id) cf_application_instances{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_name=~\"$cf_organization_name\",state=\"STARTED\"}) by(application_id))",
+          "expr": "sum(avg(cf_application_memory_mb{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\",organization_name=~\"$cf_organization_name\"} * on (application_id) cf_application_instances{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\",organization_name=~\"$cf_organization_name\",state=\"STARTED\"}) by(application_id))",
           "intervalFactor": 2,
           "legendFormat": "Used",
           "refId": "A",
           "step": 4
         },
         {
-          "expr": "avg(cf_organization_total_memory_mb_quota{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_name=~\"$cf_organization_name\"})",
+          "expr": "avg(cf_organization_total_memory_mb_quota{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\",organization_name=~\"$cf_organization_name\"})",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Quota",
@@ -343,7 +343,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(cf_application_disk_quota_mb{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_name=~\"$cf_organization_name\"} * on (application_id) cf_application_instances{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_name=~\"$cf_organization_name\",state=\"STARTED\"}) by(application_id))",
+          "expr": "sum(avg(cf_application_disk_quota_mb{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\",organization_name=~\"$cf_organization_name\"} * on (application_id) cf_application_instances{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\",organization_name=~\"$cf_organization_name\",state=\"STARTED\"}) by(application_id))",
           "intervalFactor": 2,
           "legendFormat": "Used",
           "refId": "A",
@@ -419,7 +419,7 @@
       "strokeWidth": 1,
       "targets": [
         {
-          "expr": "sum(avg(cf_application_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_name=~\"$cf_organization_name\"}) by(application_id, stack_id)) by(stack_id) * on(stack_id) group_left(stack_name) count(cf_stack_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\"}) by(stack_id, stack_name)",
+          "expr": "sum(avg(cf_application_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\",organization_name=~\"$cf_organization_name\"}) by(application_id, stack_id)) by(stack_id) * on(stack_id) group_left(stack_name) count(cf_stack_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(stack_id, stack_name)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ stack_name }}",
@@ -464,7 +464,7 @@
       "strokeWidth": 1,
       "targets": [
         {
-          "expr": "sum(avg(cf_application_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_name=~\"$cf_organization_name\"}) by(application_id, buildpack)) by(buildpack)",
+          "expr": "sum(avg(cf_application_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\",organization_name=~\"$cf_organization_name\"}) by(application_id, buildpack)) by(buildpack)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ buildpack }}",
@@ -536,7 +536,7 @@
         "multi": false,
         "name": "cf_organization_name",
         "options": [],
-        "query": "label_values(cf_organization_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\"}, organization_name)",
+        "query": "label_values(cf_organization_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}\"}, organization_name)",
         "refresh": 1,
         "regex": "",
         "sort": 1,

--- a/jobs/cloudfoundry_dashboards/templates/cf_route_emitter.json
+++ b/jobs/cloudfoundry_dashboards/templates/cf_route_emitter.json
@@ -110,7 +110,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_value_metric_route_emitter_routes_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"})",
+          "expr": "avg(firehose_value_metric_route_emitter_routes_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"})",
           "intervalFactor": 2,
           "legendFormat": "Number of Routes",
           "refId": "A",
@@ -197,14 +197,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(firehose_counter_event_route_emitter_routes_registered_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_route_emitter_routes_registered_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "Registered",
           "refId": "A",
           "step": 2
         },
         {
-          "expr": "sum(avg(firehose_counter_event_route_emitter_routes_synced_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_route_emitter_routes_synced_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Synched",
@@ -212,7 +212,7 @@
           "step": 2
         },
         {
-          "expr": "sum(avg(firehose_counter_event_route_emitter_routes_unregistered_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_route_emitter_routes_unregistered_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "Unregistered",
           "refId": "C",
@@ -299,7 +299,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(firehose_counter_event_route_emitter_messages_emitted_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_route_emitter_messages_emitted_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "Messages Emitted",
           "refId": "A",

--- a/jobs/cloudfoundry_dashboards/templates/cf_router.json
+++ b/jobs/cloudfoundry_dashboards/templates/cf_router.json
@@ -112,7 +112,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(rate(firehose_counter_event_gorouter_total_requests_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}[5m])) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(rate(firehose_counter_event_gorouter_total_requests_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}[5m])) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Total",
@@ -120,7 +120,7 @@
           "step": 4
         },
         {
-          "expr": "sum(avg(rate(firehose_counter_event_gorouter_rejected_requests_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}[5m])) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(rate(firehose_counter_event_gorouter_rejected_requests_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}[5m])) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "Rejected",
           "refId": "B",
@@ -206,28 +206,28 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(rate(firehose_counter_event_gorouter_responses_2_xx_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}[5m])) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(rate(firehose_counter_event_gorouter_responses_2_xx_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}[5m])) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "2xx",
           "refId": "B",
           "step": 4
         },
         {
-          "expr": "sum(avg(rate(firehose_counter_event_gorouter_responses_3_xx_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}[5m])) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(rate(firehose_counter_event_gorouter_responses_3_xx_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}[5m])) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "3xx",
           "refId": "C",
           "step": 4
         },
         {
-          "expr": "sum(avg(rate(firehose_counter_event_gorouter_responses_4_xx_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}[5m])) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(rate(firehose_counter_event_gorouter_responses_4_xx_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}[5m])) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "4xx",
           "refId": "D",
           "step": 4
         },
         {
-          "expr": "sum(avg(rate(firehose_counter_event_gorouter_responses_5_xx_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}[5m])) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(rate(firehose_counter_event_gorouter_responses_5_xx_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}[5m])) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "5xx",
@@ -315,7 +315,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(firehose_counter_event_gorouter_total_requests_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_gorouter_total_requests_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Total",
@@ -323,7 +323,7 @@
           "step": 4
         },
         {
-          "expr": "sum(avg(firehose_counter_event_gorouter_rejected_requests_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_gorouter_rejected_requests_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "Rejected",
           "refId": "B",
@@ -409,28 +409,28 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(firehose_counter_event_gorouter_responses_2_xx_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_gorouter_responses_2_xx_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "2xx",
           "refId": "B",
           "step": 4
         },
         {
-          "expr": "sum(avg(firehose_counter_event_gorouter_responses_3_xx_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_gorouter_responses_3_xx_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "3xx",
           "refId": "C",
           "step": 4
         },
         {
-          "expr": "sum(avg(firehose_counter_event_gorouter_responses_4_xx_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_gorouter_responses_4_xx_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "4xx",
           "refId": "D",
           "step": 4
         },
         {
-          "expr": "sum(avg(firehose_counter_event_gorouter_responses_5_xx_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_counter_event_gorouter_responses_5_xx_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "5xx",
@@ -517,7 +517,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_value_metric_gorouter_latency{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
+          "expr": "avg(firehose_value_metric_gorouter_latency{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
           "intervalFactor": 2,
           "legendFormat": "{{ bosh_deployment }}/{{ bosh_job_name }}/{{ bosh_job_ip }}",
           "refId": "A",
@@ -603,7 +603,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_value_metric_gorouter_route_lookup_time{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
+          "expr": "avg(firehose_value_metric_gorouter_route_lookup_time{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ bosh_deployment }}/{{ bosh_job_name }}/{{ bosh_job_ip }}",
@@ -690,7 +690,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(firehose_counter_event_gorouter_registry_message_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}[5m])) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
+          "expr": "avg(rate(firehose_counter_event_gorouter_registry_message_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}[5m])) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ bosh_deployment }}/{{ bosh_job_name }}/{{ bosh_job_ip }}",
@@ -777,7 +777,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_counter_event_gorouter_registry_message_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
+          "expr": "avg(firehose_counter_event_gorouter_registry_message_total{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ bosh_deployment }}/{{ bosh_job_name }}/{{ bosh_job_ip }}",
@@ -864,7 +864,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_value_metric_gorouter_total_routes{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"})",
+          "expr": "avg(firehose_value_metric_gorouter_total_routes{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"})",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Routes",

--- a/jobs/cloudfoundry_dashboards/templates/cf_services.json
+++ b/jobs/cloudfoundry_dashboards/templates/cf_services.json
@@ -139,7 +139,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(min(cf_service_instance_info{environment=~\"$environment\", deployment=~\"$bosh_deployment\", service_plan_id=~\"$service_plan_id\"}) by(service_instance_id))",
+          "expr": "sum(min(cf_service_instance_info{environment=~\"$environment\", deployment=~\"${bosh_deployment}[-0-9a-f]*\", service_plan_id=~\"$service_plan_id\"}) by(service_instance_id))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",
@@ -199,7 +199,7 @@
       ],
       "targets": [
         {
-          "expr": "count(cf_service_instance_info{environment=~\"$environment\", deployment=~\"$bosh_deployment\", service_plan_id=~\"$service_plan_id\"}) by(service_instance_name, space_id) * on(space_id) group_left(space_name, organization_id) count(cf_space_info{environment=~\"$environment\", deployment=~\"$bosh_deployment\"}) by(space_id, space_name, organization_id) * on(organization_id) group_left(organization_name) count(cf_organization_info{environment=~\"$environment\", deployment=~\"$bosh_deployment\"}) by(organization_id, organization_name)",
+          "expr": "count(cf_service_instance_info{environment=~\"$environment\", deployment=~\"${bosh_deployment}[-0-9a-f]*\", service_plan_id=~\"$service_plan_id\"}) by(service_instance_name, space_id) * on(space_id) group_left(space_name, organization_id) count(cf_space_info{environment=~\"$environment\", deployment=~\"${bosh_deployment}\"}) by(space_id, space_name, organization_id) * on(organization_id) group_left(organization_name) count(cf_organization_info{environment=~\"$environment\", deployment=~\"${bosh_deployment}\"}) by(organization_id, organization_name)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -276,7 +276,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(min(cf_service_binding_info{environment=~\"$environment\", deployment=~\"$bosh_deployment\"}) by(service_binding_id, service_instance_id) * on(service_instance_id) group_left(service_plan_id) min(cf_service_instance_info{environment=~\"$environment\", deployment=~\"$bosh_deployment\", service_plan_id=~\"$service_plan_id\"}) by(service_instance_id, service_plan_id)) ",
+          "expr": "sum(min(cf_service_binding_info{environment=~\"$environment\", deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(service_binding_id, service_instance_id) * on(service_instance_id) group_left(service_plan_id) min(cf_service_instance_info{environment=~\"$environment\", deployment=~\"${bosh_deployment}[-0-9a-f]*\", service_plan_id=~\"$service_plan_id\"}) by(service_instance_id, service_plan_id)) ",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",
@@ -336,7 +336,7 @@
       ],
       "targets": [
         {
-          "expr": "count(cf_service_binding_info{environment=~\"$environment\", deployment=~\"$bosh_deployment\"}) by(application_id, service_binding_id, service_instance_id) * on(service_instance_id) group_left(service_instance_name) count(cf_service_instance_info{environment=~\"$environment\", deployment=~\"$bosh_deployment\", service_plan_id=~\"$service_plan_id\"}) by(service_instance_id, service_instance_name) * on(application_id) group_left(organization_name, space_name, application_name)  count(cf_application_info{environment=~\"$environment\", deployment=~\"$bosh_deployment\"}) by(organization_name, space_name, application_id, application_name)",
+          "expr": "count(cf_service_binding_info{environment=~\"$environment\", deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(application_id, service_binding_id, service_instance_id) * on(service_instance_id) group_left(service_instance_name) count(cf_service_instance_info{environment=~\"$environment\", deployment=~\"${bosh_deployment}[-0-9a-f]*\", service_plan_id=~\"$service_plan_id\"}) by(service_instance_id, service_instance_name) * on(application_id) group_left(organization_name, space_name, application_name)  count(cf_application_info{environment=~\"$environment\", deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) by(organization_name, space_name, application_id, application_name)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -409,7 +409,7 @@
         "multi": false,
         "name": "service_name",
         "options": [],
-        "query": "label_values(cf_service_info{environment=~\"$environment\", deployment=~\"$bosh_deployment\"}, service_label)",
+        "query": "label_values(cf_service_info{environment=~\"$environment\", deployment=~\"${bosh_deployment}\"}, service_label)",
         "refresh": 1,
         "regex": "",
         "sort": 1,
@@ -429,7 +429,7 @@
         "multi": false,
         "name": "service_id",
         "options": [],
-        "query": "label_values(cf_service_info{environment=~\"$environment\", deployment=~\"$bosh_deployment\", service_label=\"$service_name\"}, service_id)",
+        "query": "label_values(cf_service_info{environment=~\"$environment\", deployment=~\"${bosh_deployment}\", service_label=\"$service_name\"}, service_id)",
         "refresh": 1,
         "regex": "",
         "sort": 1,
@@ -449,7 +449,7 @@
         "multi": false,
         "name": "service_plan_name",
         "options": [],
-        "query": "label_values(cf_service_plan_info{environment=~\"$environment\", deployment=~\"$bosh_deployment\", service_id=~\"$service_id\"}, service_plan_name)",
+        "query": "label_values(cf_service_plan_info{environment=~\"$environment\", deployment=~\"${bosh_deployment}\", service_id=~\"$service_id\"}, service_plan_name)",
         "refresh": 1,
         "regex": "",
         "sort": 1,
@@ -469,7 +469,7 @@
         "multi": false,
         "name": "service_plan_id",
         "options": [],
-        "query": "label_values(cf_service_plan_info{environment=~\"$environment\", deployment=~\"$bosh_deployment\", service_id=~\"$service_id\", service_plan_name=\"$service_plan_name\"}, service_plan_id)",
+        "query": "label_values(cf_service_plan_info{environment=~\"$environment\", deployment=~\"${bosh_deployment}\", service_id=~\"$service_id\", service_plan_name=\"$service_plan_name\"}, service_plan_id)",
         "refresh": 2,
         "regex": "",
         "sort": 1,

--- a/jobs/cloudfoundry_dashboards/templates/cf_space_summary.json
+++ b/jobs/cloudfoundry_dashboards/templates/cf_space_summary.json
@@ -115,7 +115,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(cf_application_instances{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_id=~\"$cf_organization_id\",space_name=~\"$cf_space_name\",state=\"STARTED\"}) by(application_id))",
+          "expr": "sum(avg(cf_application_instances{environment=~\"$environment\",deployment=~\"${bosh_deployment}\",organization_id=~\"$cf_organization_id\",space_name=~\"$cf_space_name\",state=\"STARTED\"}) by(application_id))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Used",
@@ -123,7 +123,7 @@
           "step": 4
         },
         {
-          "expr": "avg(cf_space_total_app_instances_quota{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_id=~\"$cf_organization_id\",space_name=~\"$cf_space_name\"})",
+          "expr": "avg(cf_space_total_app_instances_quota{environment=~\"$environment\",deployment=~\"${bosh_deployment}\",organization_id=~\"$cf_organization_id\",space_name=~\"$cf_space_name\"})",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Quota",
@@ -200,7 +200,7 @@
       "strokeWidth": 1,
       "targets": [
         {
-          "expr": "sum(avg(cf_application_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_id=~\"$cf_organization_id\",space_name=~\"$cf_space_name\"}) by(application_id, state)) by(state) ",
+          "expr": "sum(avg(cf_application_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}\",organization_id=~\"$cf_organization_id\",space_name=~\"$cf_space_name\"}) by(application_id, state)) by(state) ",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ state }}",
@@ -252,14 +252,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(cf_application_memory_mb{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_id=~\"$cf_organization_id\",space_name=~\"$cf_space_name\"} * on (application_id) cf_application_instances{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_id=~\"$cf_organization_id\",space_name=~\"$cf_space_name\",state=\"STARTED\"}) by(application_id))",
+          "expr": "sum(avg(cf_application_memory_mb{environment=~\"$environment\",deployment=~\"${bosh_deployment}\",organization_id=~\"$cf_organization_id\",space_name=~\"$cf_space_name\"} * on (application_id) cf_application_instances{environment=~\"$environment\",deployment=~\"${bosh_deployment}\",organization_id=~\"$cf_organization_id\",space_name=~\"$cf_space_name\",state=\"STARTED\"}) by(application_id))",
           "intervalFactor": 2,
           "legendFormat": "Used",
           "refId": "A",
           "step": 4
         },
         {
-          "expr": "avg(cf_space_total_memory_mb_quota{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_id=~\"$cf_organization_id\",space_name=~\"$cf_space_name\"})",
+          "expr": "avg(cf_space_total_memory_mb_quota{environment=~\"$environment\",deployment=~\"${bosh_deployment}\",organization_id=~\"$cf_organization_id\",space_name=~\"$cf_space_name\"})",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Quota",
@@ -343,7 +343,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(cf_application_disk_quota_mb{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_id=~\"$cf_organization_id\",space_name=~\"$cf_space_name\"} * on (application_id) cf_application_instances{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_id=~\"$cf_organization_id\",space_name=~\"$cf_space_name\",state=\"STARTED\"}) by(application_id))",
+          "expr": "sum(avg(cf_application_disk_quota_mb{environment=~\"$environment\",deployment=~\"${bosh_deployment}\",organization_id=~\"$cf_organization_id\",space_name=~\"$cf_space_name\"} * on (application_id) cf_application_instances{environment=~\"$environment\",deployment=~\"${bosh_deployment}\",organization_id=~\"$cf_organization_id\",space_name=~\"$cf_space_name\",state=\"STARTED\"}) by(application_id))",
           "intervalFactor": 2,
           "legendFormat": "Used",
           "refId": "A",
@@ -424,7 +424,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(cf_route_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\",space_id=~\"$cf_space_id\"}) by(route_id))",
+          "expr": "sum(avg(cf_route_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}\",space_id=~\"$cf_space_id\"}) by(route_id))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Used",
@@ -432,7 +432,7 @@
           "step": 4
         },
         {
-          "expr": "avg(cf_space_total_routes_quota{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_id=~\"$cf_organization_id\",space_name=~\"$cf_space_name\"})",
+          "expr": "avg(cf_space_total_routes_quota{environment=~\"$environment\",deployment=~\"${bosh_deployment}\",organization_id=~\"$cf_organization_id\",space_name=~\"$cf_space_name\"})",
           "intervalFactor": 2,
           "legendFormat": "Quota",
           "refId": "B",
@@ -513,7 +513,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(cf_service_instance_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\",space_id=~\"$cf_space_id\"}) by(service_instance_id))",
+          "expr": "sum(avg(cf_service_instance_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}\",space_id=~\"$cf_space_id\"}) by(service_instance_id))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Used",
@@ -521,7 +521,7 @@
           "step": 4
         },
         {
-          "expr": "avg(cf_space_total_services_quota{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_id=~\"$cf_organization_id\",space_name=~\"$cf_space_name\"})",
+          "expr": "avg(cf_space_total_services_quota{environment=~\"$environment\",deployment=~\"${bosh_deployment}\",organization_id=~\"$cf_organization_id\",space_name=~\"$cf_space_name\"})",
           "intervalFactor": 2,
           "legendFormat": "Quota",
           "refId": "B",
@@ -597,7 +597,7 @@
       "strokeWidth": 1,
       "targets": [
         {
-          "expr": "sum(avg(cf_application_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_id=~\"$cf_organization_id\",space_name=~\"$cf_space_name\"}) by(application_id, stack_id)) by(stack_id) * on(stack_id) group_left(stack_name) count(cf_stack_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\"}) by(stack_id, stack_name)",
+          "expr": "sum(avg(cf_application_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}\",organization_id=~\"$cf_organization_id\",space_name=~\"$cf_space_name\"}) by(application_id, stack_id)) by(stack_id) * on(stack_id) group_left(stack_name) count(cf_stack_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}\"}) by(stack_id, stack_name)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ stack_name }}",
@@ -642,7 +642,7 @@
       "strokeWidth": 1,
       "targets": [
         {
-          "expr": "sum(avg(cf_application_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_id=~\"$cf_organization_id\",space_name=~\"$cf_space_name\"}) by(application_id, buildpack)) by(buildpack)",
+          "expr": "sum(avg(cf_application_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}\",organization_id=~\"$cf_organization_id\",space_name=~\"$cf_space_name\"}) by(application_id, buildpack)) by(buildpack)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ buildpack }}",
@@ -714,7 +714,7 @@
         "multi": false,
         "name": "cf_organization_name",
         "options": [],
-        "query": "label_values(cf_organization_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\"}, organization_name)",
+        "query": "label_values(cf_organization_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}\"}, organization_name)",
         "refresh": 1,
         "regex": "",
         "sort": 1,
@@ -734,7 +734,7 @@
         "multi": false,
         "name": "cf_organization_id",
         "options": [],
-        "query": "label_values(cf_organization_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\", organization_name=~\"$cf_organization_name\"}, organization_id)",
+        "query": "label_values(cf_organization_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}\", organization_name=~\"$cf_organization_name\"}, organization_id)",
         "refresh": 1,
         "regex": "",
         "sort": 0,
@@ -754,7 +754,7 @@
         "multi": false,
         "name": "cf_space_name",
         "options": [],
-        "query": "label_values(cf_space_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\", organization_id=~\"$cf_organization_id\"}, space_name)",
+        "query": "label_values(cf_space_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}\", organization_id=~\"$cf_organization_id\"}, space_name)",
         "refresh": 1,
         "regex": "",
         "sort": 1,
@@ -774,7 +774,7 @@
         "multi": false,
         "name": "cf_space_id",
         "options": [],
-        "query": "label_values(cf_space_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\", organization_id=~\"$cf_organization_id\", space_name=~\"$cf_space_name\"}, space_id)",
+        "query": "label_values(cf_space_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}\", organization_id=~\"$cf_organization_id\", space_name=~\"$cf_space_name\"}, space_id)",
         "refresh": 1,
         "regex": "",
         "sort": 0,

--- a/jobs/cloudfoundry_dashboards/templates/cf_summary.json
+++ b/jobs/cloudfoundry_dashboards/templates/cf_summary.json
@@ -141,7 +141,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "avg(firehose_value_metric_cc_total_users{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"})",
+          "expr": "avg(firehose_value_metric_cc_total_users{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"})",
           "intervalFactor": 2,
           "refId": "A",
           "step": 60
@@ -201,7 +201,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_value_metric_cc_total_users{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"})",
+          "expr": "avg(firehose_value_metric_cc_total_users{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\"})",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Number of Users",
@@ -311,7 +311,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(avg(cf_application_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\"}) without(instance))",
+          "expr": "sum(avg(cf_application_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) without(instance))",
           "intervalFactor": 2,
           "refId": "A",
           "step": 60
@@ -372,7 +372,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(cf_application_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\"}) without(instance))",
+          "expr": "sum(avg(cf_application_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) without(instance))",
           "intervalFactor": 2,
           "legendFormat": "Number of Applications",
           "metric": "N",
@@ -482,7 +482,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(avg(cf_organization_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\"}) without(instance))",
+          "expr": "sum(avg(cf_organization_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}\"}) without(instance))",
           "intervalFactor": 2,
           "refId": "A",
           "step": 60
@@ -544,7 +544,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(cf_organization_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\"}) without(instance))",
+          "expr": "sum(avg(cf_organization_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}\"}) without(instance))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Number of Organizations",
@@ -654,7 +654,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(avg(cf_route_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\"}) without(instance))",
+          "expr": "sum(avg(cf_route_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) without(instance))",
           "intervalFactor": 2,
           "refId": "A",
           "step": 60
@@ -716,7 +716,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(cf_route_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\"}) without(instance))",
+          "expr": "sum(avg(cf_route_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) without(instance))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Number of Routes",
@@ -827,7 +827,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(avg(cf_service_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\"}) without(instance))",
+          "expr": "sum(avg(cf_service_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}\"}) without(instance))",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A",
@@ -890,7 +890,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(cf_service_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\"}) without(instance))",
+          "expr": "sum(avg(cf_service_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}\"}) without(instance))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Number of Services",
@@ -1001,7 +1001,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(avg(cf_service_instance_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\"}) without(instance))",
+          "expr": "sum(avg(cf_service_instance_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) without(instance))",
           "intervalFactor": 2,
           "refId": "A",
           "step": 60
@@ -1060,7 +1060,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(cf_service_instance_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\"}) without(instance))",
+          "expr": "sum(avg(cf_service_instance_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) without(instance))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Number of Service Instances",
@@ -1169,7 +1169,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(avg(cf_service_binding_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\"}) without(instance))",
+          "expr": "sum(avg(cf_service_binding_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) without(instance))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",
@@ -1233,7 +1233,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(cf_service_binding_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\"}) without(instance))",
+          "expr": "sum(avg(cf_service_binding_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) without(instance))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -1344,7 +1344,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(avg(cf_space_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\"}) without(instance))",
+          "expr": "sum(avg(cf_space_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}\"}) without(instance))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",
@@ -1408,7 +1408,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(cf_space_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\"}) without(instance))",
+          "expr": "sum(avg(cf_space_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}\"}) without(instance))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -1519,7 +1519,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(avg(cf_security_group_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\"}) without(instance))",
+          "expr": "sum(avg(cf_security_group_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) without(instance))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",
@@ -1580,7 +1580,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(cf_security_group_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\"}) without(instance))",
+          "expr": "sum(avg(cf_security_group_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) without(instance))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Number of Security Groups",
@@ -1689,7 +1689,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(avg(cf_stack_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\"}) without(instance))",
+          "expr": "sum(avg(cf_stack_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) without(instance))",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A",
@@ -1748,7 +1748,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(cf_stack_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\"}) without(instance))",
+          "expr": "sum(avg(cf_stack_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\"}) without(instance))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Number of Stacks",

--- a/jobs/cloudfoundry_dashboards/templates/cf_uaa.json
+++ b/jobs/cloudfoundry_dashboards/templates/cf_uaa.json
@@ -111,7 +111,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(avg(firehose_value_metric_gorouter_latency_uaa{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "avg(avg(firehose_value_metric_gorouter_latency_uaa{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "UAA Latency",
           "refId": "A",
@@ -197,7 +197,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(avg(rate(firehose_value_metric_uaa_requests_global_status_5_xx_count{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}[5m]) / rate(firehose_value_metric_uaa_requests_global_completed_count{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}[5m])) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "avg(avg(rate(firehose_value_metric_uaa_requests_global_status_5_xx_count{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}\"}[5m]) / rate(firehose_value_metric_uaa_requests_global_completed_count{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}\"}[5m])) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "UAA Error Rate",
           "refId": "A",
@@ -283,7 +283,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(firehose_value_metric_uaa_audit_service_user_not_found_count{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_uaa_audit_service_user_not_found_count{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "User Not Found",
           "refId": "A",
@@ -369,7 +369,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(firehose_value_metric_uaa_audit_service_principal_authentication_failure_count{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_uaa_audit_service_principal_authentication_failure_count{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "Non-user Authentication Attempts",
           "refId": "A",
@@ -455,7 +455,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(firehose_value_metric_uaa_audit_service_user_authentication_count{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_uaa_audit_service_user_authentication_count{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Successful User Authentications",
@@ -542,7 +542,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(firehose_value_metric_uaa_audit_service_user_authentication_failure_count{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_uaa_audit_service_user_authentication_failure_count{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "Failed User Authentications",
           "refId": "A",
@@ -625,7 +625,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(firehose_value_metric_uaa_audit_service_client_authentication_count{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_uaa_audit_service_client_authentication_count{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "Successful Client Authentications",
           "refId": "A",
@@ -707,7 +707,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(firehose_value_metric_uaa_audit_service_client_authentication_failure_count{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_uaa_audit_service_client_authentication_failure_count{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "Failed Client Authentications",
           "refId": "A",
@@ -792,7 +792,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(firehose_value_metric_uaa_audit_service_user_password_changes{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_uaa_audit_service_user_password_changes{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "Successful Password Changes",
           "refId": "A",
@@ -878,7 +878,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(avg(firehose_value_metric_uaa_audit_service_user_password_failures{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
+          "expr": "sum(avg(firehose_value_metric_uaa_audit_service_user_password_failures{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}\"}) by(bosh_deployment, bosh_job_name, bosh_job_ip))",
           "intervalFactor": 2,
           "legendFormat": "Failed Password Changes",
           "refId": "A",


### PR DESCRIPTION
At one time (not sure when), many of the CF dashboards no longer show any data (if they ever did). After investigation, I found it was due to the bosh_deployment name being "cf", instead of "cf-[0-9a-f]*". I updated the json files to fix the issue, and also backward compatible. The following is a list of issues and the result with the fix.

Apps:Latency   (no data) [fixed]
Apps: Requests (no data) [fixed]
Apps: System (incomplete data) [fixed]
CF:Organization Memory Quotas (no data for "Organization's Memory Quota Consumption") [fixed]
CF:Route Emitter (no data) [fixed]
CF:Summary (no data for "Users") [fixed]
Component Metrics (no data) [improved]

Also fixed the CF:App:Requests dashboard error when multiple firehose exporters are configured.

Thanks
Yansheng