### PR TITLE
fix http_config option to work

### DIFF
--- a/manifests/operators/proxy/enable-proxy-alertmanager.yml
+++ b/manifests/operators/proxy/enable-proxy-alertmanager.yml
@@ -1,3 +1,3 @@
 - type: replace
-  path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties?/http_config
+  path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties/alertmanager?/http_config
   value: ((http_config))


### PR DESCRIPTION
Fix http_config option so it appears as a global option in alertmanager.yml.
Previous setup was not working.