### PR TITLE
bump credhub_exporter to v0.2.2

### DIFF
--- a/packages/credhub_exporter/packaging
+++ b/packages/credhub_exporter/packaging
@@ -2,6 +2,5 @@
 
 set -eux
 
-# Extract credhub_exporter package
 mkdir -p ${BOSH_INSTALL_TARGET}/bin
-unzip credhub_exporter/credhub_exporter-0.2.0-linux_amd64-0.2-0.zip credhub_exporter -d ${BOSH_INSTALL_TARGET}/bin
+tar zxf credhub_exporter/credhub_exporter_0.2.2_linux_amd64.tar.gz --strip 1 -C ${BOSH_INSTALL_TARGET}/bin

--- a/packages/credhub_exporter/spec
+++ b/packages/credhub_exporter/spec
@@ -2,5 +2,6 @@
 name: credhub_exporter
 
 files:
-  - credhub_exporter/credhub_exporter-0.2.0-linux_amd64-0.2-0.zip
+  - credhub_exporter/credhub_exporter_0.2.2_linux_amd64.tar.gz
+
 


### PR DESCRIPTION
### changelog

This PR bumps credhub-exporter to [v0.2.2](https://github.com/orange-cloudfoundry/credhub_exporter/releases/tag/v0.2.2)

### blobs
```
# fetch credhub exporter new release
wget https://github.com/orange-cloudfoundry/credhub_exporter/releases/download/v0.2.2/credhub_exporter_0.2.2_linux_amd64.tar.gz

# add tarball to blobs
bosh add-blob credhub_exporter_0.2.2_linux_amd64.tar.gz credhub_exporter/credhub_exporter_0.2.2_linux_amd64.tar.gz

# remove old blob
bosh remove-blob credhub_exporter/credhub_exporter-0.2.0-linux_amd64-0.2-0.zip
```