### PR TITLE
New implementation of firehose_exporter

### DIFF
--- a/jobs/cloudfoundry_dashboards/templates/cf_apps_latency.json
+++ b/jobs/cloudfoundry_dashboards/templates/cf_apps_latency.json
@@ -46,7 +46,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1523189342281,
+  "iteration": 1612182921378,
   "links": [
     {
       "asDropdown": true,
@@ -72,12 +72,14 @@
       "editable": true,
       "error": false,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 5,
         "w": 24,
         "x": 0,
         "y": 0
       },
+      "hiddenSeries": false,
       "id": 3,
       "legend": {
         "alignAsTable": true,
@@ -87,6 +89,7 @@
         "min": true,
         "rightSide": true,
         "show": true,
+        "sideWidth": null,
         "total": false,
         "values": true
       },
@@ -104,23 +107,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_http_start_stop_client_request_duration_seconds_sum{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"} / firehose_http_start_stop_client_request_duration_seconds_count{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"})",
+          "expr": "avg(rate(firehose_http_duration_seconds_sum{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}[5m]) / rate(firehose_http_duration_seconds_count{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}[5m]))",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Client",
           "refId": "A",
           "step": 2
-        },
-        {
-          "expr": "avg(firehose_http_start_stop_server_request_duration_seconds_sum{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"} / firehose_http_start_stop_server_request_duration_seconds_count{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"})",
-          "intervalFactor": 2,
-          "legendFormat": "Server",
-          "refId": "B",
-          "step": 2
         }
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Latency",
       "tooltip": {
@@ -155,7 +152,11 @@
           "min": null,
           "show": false
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -164,32 +165,34 @@
       "dashes": false,
       "datasource": "${DS_PROMETHEUS}",
       "decimals": null,
-      "description": "Client Latency by Quantiles.",
-      "editable": true,
-      "error": false,
-      "fill": 1,
+      "description": "Percentage of requests processed in less than a given time for selected app",
+      "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
-        "h": 5,
+        "h": 6,
         "w": 24,
         "x": 0,
         "y": 5
       },
-      "id": 1,
+      "hiddenSeries": false,
+      "id": 5,
       "legend": {
         "alignAsTable": true,
         "avg": true,
         "current": true,
-        "max": true,
-        "min": true,
+        "max": false,
+        "min": false,
         "rightSide": true,
         "show": true,
+        "sort": "current",
+        "sortDesc": false,
         "total": false,
         "values": true
       },
       "lines": true,
-      "linewidth": 1,
+      "linewidth": 2,
       "links": [],
-      "nullPointMode": "connected",
+      "nullPointMode": "null",
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -200,22 +203,95 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_http_start_stop_client_request_duration_seconds{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"}) by(quantile)",
+          "expr": "sum(rate(firehose_http_duration_seconds_bucket{le=\"0.005\", environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}[5m])) by (le)  \n/ on()\nsum(rate(firehose_http_duration_seconds_count{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}[5m]))\n* 100",
+          "format": "time_series",
+          "instant": false,
           "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "{{ quantile }}",
-          "refId": "A",
-          "step": 2
+          "intervalFactor": 1,
+          "legendFormat": "5 ms",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(firehose_http_duration_seconds_bucket{le=\"0.01\", environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}[5m])) by (le)  \n/ on()\nsum(rate(firehose_http_duration_seconds_count{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}[5m]))\n* 100",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "10 ms",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(rate(firehose_http_duration_seconds_bucket{le=\"0.1\", environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}[5m])) by (le)  \n/ on()\nsum(rate(firehose_http_duration_seconds_count{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}[5m]))\n* 100",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "100 ms",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(rate(firehose_http_duration_seconds_bucket{le=\"0.25\", environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}[5m])) by (le)  \n/ on()\nsum(rate(firehose_http_duration_seconds_count{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}[5m]))\n* 100",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "250 ms",
+          "refId": "D"
+        },
+        {
+          "expr": "sum(rate(firehose_http_duration_seconds_bucket{le=\"0.5\", environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}[5m])) by (le)  \n/ on()\nsum(rate(firehose_http_duration_seconds_count{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}[5m]))\n* 100",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "500 ms",
+          "refId": "E"
+        },
+        {
+          "expr": "sum(rate(firehose_http_duration_seconds_bucket{le=\"1\", environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}[5m])) by (le)  \n/ on()\nsum(rate(firehose_http_duration_seconds_count{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}[5m]))\n* 100",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "1 s",
+          "refId": "F"
+        },
+        {
+          "expr": "sum(rate(firehose_http_duration_seconds_bucket{le=\"2.5\", environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}[5m])) by (le)  \n/ on()\nsum(rate(firehose_http_duration_seconds_count{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}[5m]))\n* 100",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "2.5 s",
+          "refId": "G"
+        },
+        {
+          "expr": "sum(rate(firehose_http_duration_seconds_bucket{le=\"5\", environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}[5m])) by (le)  \n/ on()\nsum(rate(firehose_http_duration_seconds_count{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}[5m]))\n* 100",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "5 s",
+          "refId": "H"
+        },
+        {
+          "expr": "sum(rate(firehose_http_duration_seconds_bucket{le=\"10\", environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}[5m])) by (le)  \n/ on()\nsum(rate(firehose_http_duration_seconds_count{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}[5m]))\n* 100",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "10 s",
+          "refId": "I"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
-      "title": "Client Latency (quantiles)",
+      "title": "App Response Time by Percent",
       "tooltip": {
-        "msResolution": false,
         "shared": true,
-        "sort": 0,
+        "sort": 1,
         "value_type": "individual"
       },
       "transparent": true,
@@ -229,11 +305,11 @@
       },
       "yaxes": [
         {
-          "format": "s",
+          "format": "percent",
           "label": null,
           "logBase": 1,
-          "max": null,
-          "min": "0",
+          "max": "100",
+          "min": null,
           "show": true
         },
         {
@@ -242,9 +318,83 @@
           "logBase": 1,
           "max": null,
           "min": null,
-          "show": false
+          "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "cards": {
+        "cardPadding": null,
+        "cardRound": null
+      },
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateOranges",
+        "exponent": 0.4,
+        "mode": "opacity"
+      },
+      "dataFormat": "tsbuckets",
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 11
+      },
+      "heatmap": {},
+      "hideZeroBuckets": false,
+      "highlightCards": true,
+      "id": 8,
+      "legend": {
+        "show": false
+      },
+      "reverseYBuckets": false,
+      "targets": [
+        {
+          "expr": "sum(rate(firehose_http_duration_seconds_bucket{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}[10m])) by (le)",
+          "format": "heatmap",
+          "interval": "",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "App Global Response Time",
+      "tooltip": {
+        "show": true,
+        "showHistogram": false
+      },
+      "transparent": true,
+      "type": "heatmap",
+      "xAxis": {
+        "show": true
+      },
+      "xBucketNumber": null,
+      "xBucketSize": null,
+      "yAxis": {
+        "decimals": null,
+        "format": "s",
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": true,
+        "splitFactor": null
+      },
+      "yBucketBound": "auto",
+      "yBucketNumber": null,
+      "yBucketSize": null
     },
     {
       "aliasColors": {},
@@ -253,32 +403,41 @@
       "dashes": false,
       "datasource": "${DS_PROMETHEUS}",
       "decimals": null,
-      "description": "Server Latency by Quantiles.",
-      "editable": true,
-      "error": false,
-      "fill": 1,
+      "description": "Percentage of requests processed in less than a given time for selected app",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
-        "h": 5,
+        "h": 6,
         "w": 24,
         "x": 0,
-        "y": 10
+        "y": 18
       },
-      "id": 2,
+      "hiddenSeries": false,
+      "id": 9,
       "legend": {
         "alignAsTable": true,
         "avg": true,
         "current": true,
-        "max": true,
-        "min": true,
+        "max": false,
+        "min": false,
         "rightSide": true,
         "show": true,
+        "sort": "current",
+        "sortDesc": false,
         "total": false,
         "values": true
       },
       "lines": true,
-      "linewidth": 1,
+      "linewidth": 2,
       "links": [],
-      "nullPointMode": "connected",
+      "nullPointMode": "null",
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -289,21 +448,95 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_http_start_stop_server_request_duration_seconds{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"}) by(quantile)",
-          "intervalFactor": 2,
-          "legendFormat": "{{ quantile }}",
-          "refId": "A",
-          "step": 2
+          "expr": "sum(firehose_http_duration_seconds_bucket{le=\"0.005\", environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}) by (le)  \n/ on()\nsum(firehose_http_duration_seconds_count{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"})\n* 100",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "5 ms",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(firehose_http_duration_seconds_bucket{le=\"0.01\", environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}) by (le)  \n/ on()\nsum(firehose_http_duration_seconds_count{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"})\n* 100",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "10 ms",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(firehose_http_duration_seconds_bucket{le=\"0.1\", environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}) by (le)  \n/ on()\nsum(firehose_http_duration_seconds_count{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"})\n* 100",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "100 ms",
+          "refId": "C"
+        },
+        {
+          "expr": "sum(firehose_http_duration_seconds_bucket{le=\"0.25\", environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}) by (le)  \n/ on()\nsum(firehose_http_duration_seconds_count{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"})\n* 100",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "250 ms",
+          "refId": "D"
+        },
+        {
+          "expr": "sum(firehose_http_duration_seconds_bucket{le=\"0.5\", environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}) by (le)  \n/ on()\nsum(firehose_http_duration_seconds_count{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"})\n* 100",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "500 ms",
+          "refId": "E"
+        },
+        {
+          "expr": "sum(firehose_http_duration_seconds_bucket{le=\"1\", environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}) by (le)  \n/ on()\nsum(firehose_http_duration_seconds_count{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"})\n* 100",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "1 s",
+          "refId": "F"
+        },
+        {
+          "expr": "sum(firehose_http_duration_seconds_bucket{le=\"2.5\", environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}) by (le)  \n/ on()\nsum(firehose_http_duration_seconds_count{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"})\n* 100",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "2.5 s",
+          "refId": "G"
+        },
+        {
+          "expr": "sum(firehose_http_duration_seconds_bucket{le=\"5\", environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}) by (le)  \n/ on()\nsum(firehose_http_duration_seconds_count{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"})\n* 100",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "5 s",
+          "refId": "H"
+        },
+        {
+          "expr": "sum(firehose_http_duration_seconds_bucket{le=\"10\", environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}) by (le)  \n/ on()\nsum(firehose_http_duration_seconds_count{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"})\n* 100",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "10 s",
+          "refId": "I"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
-      "title": "Server Latency (quantiles)",
+      "title": "Q.O.S.",
       "tooltip": {
-        "msResolution": false,
         "shared": true,
-        "sort": 0,
+        "sort": 1,
         "value_type": "individual"
       },
       "transparent": true,
@@ -317,11 +550,11 @@
       },
       "yaxes": [
         {
-          "format": "s",
+          "format": "percent",
           "label": null,
           "logBase": 1,
-          "max": null,
-          "min": "0",
+          "max": "100",
+          "min": null,
           "show": true
         },
         {
@@ -330,13 +563,17 @@
           "logBase": 1,
           "max": null,
           "min": null,
-          "show": false
+          "show": true
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     }
   ],
   "refresh": "30s",
-  "schemaVersion": 16,
+  "schemaVersion": 17,
   "style": "dark",
   "tags": [
     "apps"
@@ -356,6 +593,7 @@
         "query": "label_values(cf_application_info, environment)",
         "refresh": 1,
         "regex": "",
+        "skipUrlSync": false,
         "sort": 1,
         "tagValuesQuery": "",
         "tags": [],
@@ -376,6 +614,7 @@
         "query": "label_values(cf_application_info{environment=~\"$environment\"}, deployment)",
         "refresh": 1,
         "regex": "",
+        "skipUrlSync": false,
         "sort": 1,
         "tagValuesQuery": "",
         "tags": [],
@@ -393,9 +632,10 @@
         "multi": false,
         "name": "cf_organization_name",
         "options": [],
-        "query": "label_values(cf_application_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\"}, organization_name)",
+        "query": "label_values(cf_application_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\"}, organization_name)",
         "refresh": 1,
         "regex": "",
+        "skipUrlSync": false,
         "sort": 1,
         "tagValuesQuery": null,
         "tags": [],
@@ -413,9 +653,10 @@
         "multi": false,
         "name": "cf_space_name",
         "options": [],
-        "query": "label_values(cf_application_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\",organization_name=~\"$cf_organization_name\"}, space_name)",
+        "query": "label_values(cf_application_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_name=~\"$cf_organization_name\"}, space_name)",
         "refresh": 1,
         "regex": "",
+        "skipUrlSync": false,
         "sort": 1,
         "tagValuesQuery": null,
         "tags": [],
@@ -433,9 +674,10 @@
         "multi": false,
         "name": "cf_application_name",
         "options": [],
-        "query": "label_values(cf_application_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\",organization_name=~\"$cf_organization_name\", space_name=~\"$cf_space_name\"}, application_name)",
+        "query": "label_values(cf_application_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_name=~\"$cf_organization_name\", space_name=~\"$cf_space_name\"}, application_name)",
         "refresh": 1,
         "regex": "",
+        "skipUrlSync": false,
         "sort": 1,
         "tagValuesQuery": null,
         "tags": [],
@@ -453,9 +695,10 @@
         "multi": false,
         "name": "cf_application_id",
         "options": [],
-        "query": "label_values(cf_application_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\",organization_name=~\"$cf_organization_name\", space_name=~\"$cf_space_name\",application_name=~\"$cf_application_name\"}, application_id)",
+        "query": "label_values(cf_application_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_name=~\"$cf_organization_name\", space_name=~\"$cf_space_name\",application_name=~\"$cf_application_name\"}, application_id)",
         "refresh": 1,
         "regex": "",
+        "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",
         "tags": [],

--- a/jobs/cloudfoundry_dashboards/templates/cf_apps_requests.json
+++ b/jobs/cloudfoundry_dashboards/templates/cf_apps_requests.json
@@ -46,7 +46,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1523191378945,
+  "iteration": 1612182921378,
   "links": [
     {
       "asDropdown": true,
@@ -73,12 +73,14 @@
       "editable": true,
       "error": false,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 5,
         "w": 6,
         "x": 0,
         "y": 0
       },
+      "hiddenSeries": false,
       "id": 1,
       "legend": {
         "avg": false,
@@ -103,7 +105,8 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"}[5m]))",
+          "expr": "sum(rate(firehose_http_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}[10m]))",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Requests",
           "refId": "A",
@@ -112,6 +115,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Rate Requests per second",
       "tooltip": {
@@ -146,7 +150,11 @@
           "min": null,
           "show": false
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -159,12 +167,14 @@
       "editable": true,
       "error": false,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 5,
         "w": 6,
         "x": 6,
         "y": 0
       },
+      "hiddenSeries": false,
       "id": 14,
       "legend": {
         "avg": false,
@@ -189,7 +199,8 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"})",
+          "expr": "sum(firehose_http_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"})",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Requests",
           "refId": "A",
@@ -198,6 +209,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Total Requests",
       "tooltip": {
@@ -232,7 +244,11 @@
           "min": null,
           "show": false
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -242,12 +258,14 @@
       "datasource": "${DS_PROMETHEUS}",
       "description": "Requests per application instance per second during the last 5 minutes.",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 5,
         "w": 6,
         "x": 12,
         "y": 0
       },
+      "hiddenSeries": false,
       "id": 7,
       "legend": {
         "avg": false,
@@ -272,7 +290,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"}[5m])) by (instance_id)",
+          "expr": "sum(rate(firehose_http_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}[10m])) by(instance_id)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ instance_id }}",
@@ -282,6 +300,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Rate Requests by Application Instance per second",
       "tooltip": {
@@ -315,7 +334,11 @@
           "min": null,
           "show": false
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -325,12 +348,14 @@
       "datasource": "${DS_PROMETHEUS}",
       "description": "Number of requests per application instance.",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 5,
         "w": 6,
         "x": 18,
         "y": 0
       },
+      "hiddenSeries": false,
       "id": 17,
       "legend": {
         "avg": false,
@@ -355,7 +380,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"}) by(instance_id)",
+          "expr": "sum(firehose_http_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}) by(instance_id)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ instance_id }}",
@@ -365,6 +390,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Total Requests by Application Instance",
       "tooltip": {
@@ -398,7 +424,11 @@
           "min": null,
           "show": false
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -409,12 +439,14 @@
       "decimals": 0,
       "description": "Requests by method per second during the last 5 mintes.",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 5,
         "w": 6,
         "x": 0,
         "y": 5
       },
+      "hiddenSeries": false,
       "id": 8,
       "legend": {
         "alignAsTable": false,
@@ -441,7 +473,8 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"}[5m])) by(method)",
+          "expr": "sum(rate(firehose_http_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}[10m])) by(method)",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ method }}",
           "refId": "A",
@@ -450,6 +483,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Rate Requests by Method per second",
       "tooltip": {
@@ -483,7 +517,11 @@
           "min": null,
           "show": false
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -494,12 +532,14 @@
       "decimals": 0,
       "description": "Number of requests by method.",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 5,
         "w": 6,
         "x": 6,
         "y": 5
       },
+      "hiddenSeries": false,
       "id": 15,
       "legend": {
         "alignAsTable": false,
@@ -526,7 +566,8 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"}) by(method)",
+          "expr": "sum(firehose_http_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}) by(method)",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ method }}",
           "refId": "A",
@@ -535,6 +576,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Total Requests by Method",
       "tooltip": {
@@ -568,7 +610,11 @@
           "min": null,
           "show": false
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -579,12 +625,14 @@
       "decimals": 0,
       "description": "Requests by status code per second during the last 5 minutes.",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 5,
         "w": 6,
         "x": 12,
         "y": 5
       },
+      "hiddenSeries": false,
       "id": 9,
       "legend": {
         "alignAsTable": false,
@@ -611,7 +659,8 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"}[5m])) by(status_code)",
+          "expr": "sum(rate(firehose_http_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}[10m])) by(status_code)",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ status_code }}",
           "refId": "A",
@@ -620,6 +669,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Rate Requests by Status Code per second",
       "tooltip": {
@@ -653,7 +703,11 @@
           "min": null,
           "show": false
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -664,12 +718,14 @@
       "decimals": 0,
       "description": "Number of requests by status code.",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 5,
         "w": 6,
         "x": 18,
         "y": 5
       },
+      "hiddenSeries": false,
       "id": 18,
       "legend": {
         "alignAsTable": false,
@@ -696,7 +752,8 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"}) by(status_code)",
+          "expr": "sum(firehose_http_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}) by(status_code)",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ status_code }}",
           "refId": "A",
@@ -705,6 +762,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Total Requests by Status Code",
       "tooltip": {
@@ -738,7 +796,11 @@
           "min": null,
           "show": false
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -749,12 +811,14 @@
       "decimals": 0,
       "description": "Requests by scheme per second during the last 5 mintes.",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 5,
         "w": 6,
         "x": 0,
         "y": 10
       },
+      "hiddenSeries": false,
       "id": 10,
       "legend": {
         "alignAsTable": false,
@@ -781,7 +845,8 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"}[5m])) by(scheme)",
+          "expr": "sum(rate(firehose_http_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}[10m])) by(scheme)",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ scheme }}",
           "refId": "A",
@@ -790,6 +855,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Rate Requests by Scheme per second",
       "tooltip": {
@@ -823,7 +889,11 @@
           "min": null,
           "show": false
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -834,12 +904,14 @@
       "decimals": 0,
       "description": "Number of requests by scheme.",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 5,
         "w": 6,
         "x": 6,
         "y": 10
       },
+      "hiddenSeries": false,
       "id": 16,
       "legend": {
         "alignAsTable": false,
@@ -866,7 +938,8 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"}) by(scheme)",
+          "expr": "sum(firehose_http_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}) by(scheme)",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ scheme }}",
           "refId": "A",
@@ -875,6 +948,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Total Requests by Scheme",
       "tooltip": {
@@ -908,7 +982,11 @@
           "min": null,
           "show": false
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -919,12 +997,14 @@
       "decimals": 0,
       "description": "Requests by host per second during the last 5 minutes.",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 5,
         "w": 6,
         "x": 12,
         "y": 10
       },
+      "hiddenSeries": false,
       "id": 11,
       "legend": {
         "alignAsTable": false,
@@ -951,7 +1031,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"}[5m])) by(host)",
+          "expr": "sum(rate(firehose_http_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}[10m])) by(host)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ host }}",
@@ -961,6 +1041,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Rate Requests by Host per second",
       "tooltip": {
@@ -994,7 +1075,11 @@
           "min": null,
           "show": false
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -1005,12 +1090,14 @@
       "decimals": 0,
       "description": "Number of requests by host.",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 5,
         "w": 6,
         "x": 18,
         "y": 10
       },
+      "hiddenSeries": false,
       "id": 19,
       "legend": {
         "alignAsTable": false,
@@ -1037,7 +1124,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(firehose_http_start_stop_requests{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"}) by(host)",
+          "expr": "sum(firehose_http_total{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}) by(host)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ host }}",
@@ -1047,6 +1134,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Total Requests by Host",
       "tooltip": {
@@ -1080,7 +1168,11 @@
           "min": null,
           "show": false
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -1090,12 +1182,14 @@
       "datasource": "${DS_PROMETHEUS}",
       "description": "Response Size.",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 5,
         "w": 12,
         "x": 0,
         "y": 15
       },
+      "hiddenSeries": false,
       "id": 12,
       "legend": {
         "alignAsTable": false,
@@ -1122,7 +1216,8 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_http_start_stop_response_size_bytes_sum{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"} / firehose_http_start_stop_response_size_bytes_count{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"})",
+          "expr": "avg(firehose_http_response_size_bytes_sum{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"} / firehose_http_response_size_bytes_count{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"})",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Size",
           "refId": "A",
@@ -1131,6 +1226,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Response Size",
       "tooltip": {
@@ -1164,7 +1260,11 @@
           "min": null,
           "show": false
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -1174,12 +1274,14 @@
       "datasource": "${DS_PROMETHEUS}",
       "description": "Response Size (Quantiles).",
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 5,
         "w": 12,
         "x": 12,
         "y": 15
       },
+      "hiddenSeries": false,
       "id": 13,
       "legend": {
         "alignAsTable": true,
@@ -1206,7 +1308,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(firehose_http_start_stop_response_size_bytes{environment=~\"$environment\",bosh_deployment=~\"${bosh_deployment}[-0-9a-f]*\",application_id=~\"$cf_application_id\"}) by(quantile)",
+          "expr": "avg(firehose_http_response_size_bytes{environment=~\"$environment\",bosh_deployment=~\"$bosh_deployment\",application_id=~\"$cf_application_id\"}) by(quantile)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{ quantile }}",
@@ -1216,6 +1318,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Response Size (Quantiles)",
       "tooltip": {
@@ -1249,11 +1352,15 @@
           "min": null,
           "show": false
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     }
   ],
   "refresh": "30s",
-  "schemaVersion": 16,
+  "schemaVersion": 17,
   "style": "dark",
   "tags": [
     "apps"
@@ -1273,6 +1380,7 @@
         "query": "label_values(cf_application_info, environment)",
         "refresh": 1,
         "regex": "",
+        "skipUrlSync": false,
         "sort": 1,
         "tagValuesQuery": "",
         "tags": [],
@@ -1293,6 +1401,7 @@
         "query": "label_values(cf_application_info{environment=~\"$environment\"}, deployment)",
         "refresh": 1,
         "regex": "",
+        "skipUrlSync": false,
         "sort": 1,
         "tagValuesQuery": "",
         "tags": [],
@@ -1310,9 +1419,10 @@
         "multi": false,
         "name": "cf_organization_name",
         "options": [],
-        "query": "label_values(cf_application_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\"}, organization_name)",
+        "query": "label_values(cf_application_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\"}, organization_name)",
         "refresh": 1,
         "regex": "",
+        "skipUrlSync": false,
         "sort": 1,
         "tagValuesQuery": null,
         "tags": [],
@@ -1330,9 +1440,10 @@
         "multi": false,
         "name": "cf_space_name",
         "options": [],
-        "query": "label_values(cf_application_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\",organization_name=~\"$cf_organization_name\"}, space_name)",
+        "query": "label_values(cf_application_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_name=~\"$cf_organization_name\"}, space_name)",
         "refresh": 1,
         "regex": "",
+        "skipUrlSync": false,
         "sort": 1,
         "tagValuesQuery": null,
         "tags": [],
@@ -1350,9 +1461,10 @@
         "multi": false,
         "name": "cf_application_name",
         "options": [],
-        "query": "label_values(cf_application_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\",organization_name=~\"$cf_organization_name\", space_name=~\"$cf_space_name\"}, application_name)",
+        "query": "label_values(cf_application_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_name=~\"$cf_organization_name\", space_name=~\"$cf_space_name\"}, application_name)",
         "refresh": 1,
         "regex": "",
+        "skipUrlSync": false,
         "sort": 1,
         "tagValuesQuery": null,
         "tags": [],
@@ -1370,9 +1482,10 @@
         "multi": false,
         "name": "cf_application_id",
         "options": [],
-        "query": "label_values(cf_application_info{environment=~\"$environment\",deployment=~\"${bosh_deployment}[-0-9a-f]*\",organization_name=~\"$cf_organization_name\", space_name=~\"$cf_space_name\",application_name=~\"$cf_application_name\"}, application_id)",
+        "query": "label_values(cf_application_info{environment=~\"$environment\",deployment=~\"$bosh_deployment\",organization_name=~\"$cf_organization_name\", space_name=~\"$cf_space_name\",application_name=~\"$cf_application_name\"}, application_id)",
         "refresh": 1,
         "regex": "",
+        "skipUrlSync": false,
         "sort": 0,
         "tagValuesQuery": "",
         "tags": [],

--- a/jobs/cloudfoundry_dashboards/templates/prometheus_firehose_exporter.json
+++ b/jobs/cloudfoundry_dashboards/templates/prometheus_firehose_exporter.json
@@ -52,7 +52,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1523193135395,
+  "iteration": 1612182921378,
   "links": [
     {
       "asDropdown": true,
@@ -78,12 +78,14 @@
       "editable": true,
       "error": false,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 5,
-        "w": 6,
+        "w": 8,
         "x": 0,
         "y": 0
       },
+      "hiddenSeries": false,
       "id": 9,
       "legend": {
         "avg": false,
@@ -126,6 +128,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Rate Envelopes & Metrics Received per second",
       "tooltip": {
@@ -160,7 +163,11 @@
           "min": null,
           "show": false
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -172,12 +179,14 @@
       "editable": true,
       "error": false,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 5,
-        "w": 6,
-        "x": 6,
+        "w": 8,
+        "x": 8,
         "y": 0
       },
+      "hiddenSeries": false,
       "id": 25,
       "legend": {
         "avg": false,
@@ -219,6 +228,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Total Envelopes & Metrics Received",
       "tooltip": {
@@ -253,7 +263,11 @@
           "min": null,
           "show": false
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "cacheTimeout": null,
@@ -279,7 +293,7 @@
       "gridPos": {
         "h": 5,
         "w": 4,
-        "x": 12,
+        "x": 16,
         "y": 0
       },
       "id": 19,
@@ -363,7 +377,7 @@
       "gridPos": {
         "h": 5,
         "w": 4,
-        "x": 16,
+        "x": 20,
         "y": 0
       },
       "id": 20,
@@ -424,100 +438,6 @@
       "valueName": "avg"
     },
     {
-      "cacheTimeout": null,
-      "colorBackground": true,
-      "colorValue": false,
-      "colors": [
-        "rgba(50, 172, 45, 0.97)",
-        "rgba(237, 129, 40, 0.89)",
-        "rgba(245, 54, 54, 0.9)"
-      ],
-      "datasource": "${DS_PROMETHEUS}",
-      "description": "Whether a slow consumer alert has been received from Cloud Foundry Firehose.",
-      "editable": true,
-      "error": false,
-      "format": "none",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 4,
-        "x": 20,
-        "y": 0
-      },
-      "id": 10,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "expr": "max(firehose_slow_consumer_alert{environment=~\"$environment\",instance=~\"$instance\"})",
-          "intervalFactor": 2,
-          "refId": "A",
-          "step": 60
-        }
-      ],
-      "thresholds": "0.9,1",
-      "title": "Slow Consumer Alert",
-      "transparent": true,
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        },
-        {
-          "op": "=",
-          "text": "OK",
-          "value": "0"
-        },
-        {
-          "op": "=",
-          "text": "NOK",
-          "value": "1"
-        }
-      ],
-      "valueName": "current"
-    },
-    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
@@ -527,12 +447,14 @@
       "editable": true,
       "error": false,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 5,
-        "w": 6,
+        "w": 9,
         "x": 0,
         "y": 5
       },
+      "hiddenSeries": false,
       "id": 1,
       "legend": {
         "avg": false,
@@ -562,17 +484,11 @@
           "legendFormat": "Received ({{ instance }})",
           "refId": "A",
           "step": 10
-        },
-        {
-          "expr": "rate(firehose_total_container_metrics_processed{environment=~\"$environment\",instance=~\"$instance\"}[5m])",
-          "intervalFactor": 2,
-          "legendFormat": "Processed ({{ instance }})",
-          "refId": "B",
-          "step": 10
         }
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Rate Container Metrics per second",
       "tooltip": {
@@ -607,7 +523,11 @@
           "min": null,
           "show": false
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -619,12 +539,14 @@
       "editable": true,
       "error": false,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 5,
-        "w": 6,
-        "x": 6,
+        "w": 9,
+        "x": 9,
         "y": 5
       },
+      "hiddenSeries": false,
       "id": 21,
       "legend": {
         "avg": false,
@@ -654,18 +576,11 @@
           "legendFormat": "Received ({{ instance }})",
           "refId": "A",
           "step": 10
-        },
-        {
-          "expr": "sum(firehose_total_container_metrics_processed{environment=~\"$environment\",instance=~\"$instance\"}) by(instance)",
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "Processed ({{ instance }})",
-          "refId": "B",
-          "step": 10
         }
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Total Container Metrics",
       "tooltip": {
@@ -700,93 +615,11 @@
           "min": null,
           "show": false
         }
-      ]
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
-      "description": "Cumulative number of ContainerMetrics cached from Cloud Foundry Firehose.",
-      "editable": true,
-      "error": false,
-      "fill": 1,
-      "gridPos": {
-        "h": 5,
-        "w": 6,
-        "x": 12,
-        "y": 5
-      },
-      "id": 16,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": false,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "connected",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "sum(firehose_container_metrics_cached{environment=~\"$environment\",instance=~\"$instance\"}) by(instance)",
-          "interval": "",
-          "intervalFactor": 2,
-          "legendFormat": "{{ instance }}",
-          "refId": "A",
-          "step": 10
-        }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Container Metrics Cached",
-      "tooltip": {
-        "msResolution": false,
-        "shared": true,
-        "sort": 0,
-        "value_type": "cumulative"
-      },
-      "transparent": true,
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": false
-        }
-      ]
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "cacheTimeout": null,
@@ -883,12 +716,14 @@
       "editable": true,
       "error": false,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 5,
-        "w": 6,
+        "w": 9,
         "x": 0,
         "y": 10
       },
+      "hiddenSeries": false,
       "id": 3,
       "legend": {
         "avg": false,
@@ -918,17 +753,11 @@
           "legendFormat": "Received ({{ instance }})",
           "refId": "A",
           "step": 10
-        },
-        {
-          "expr": "rate(firehose_total_counter_events_processed{environment=~\"$environment\",instance=~\"$instance\"}[5m])",
-          "intervalFactor": 2,
-          "legendFormat": "Processed ({{ instance }})",
-          "refId": "B",
-          "step": 10
         }
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Rate Counter Events  per second",
       "tooltip": {
@@ -963,7 +792,11 @@
           "min": null,
           "show": false
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -975,12 +808,14 @@
       "editable": true,
       "error": false,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 5,
-        "w": 6,
-        "x": 6,
+        "w": 9,
+        "x": 9,
         "y": 10
       },
+      "hiddenSeries": false,
       "id": 22,
       "legend": {
         "avg": false,
@@ -1010,17 +845,11 @@
           "legendFormat": "Received ({{ instance }})",
           "refId": "A",
           "step": 10
-        },
-        {
-          "expr": "sum(firehose_total_counter_events_processed{environment=~\"$environment\",instance=~\"$instance\"}) by(instance)",
-          "intervalFactor": 2,
-          "legendFormat": "Processed ({{ instance }})",
-          "refId": "B",
-          "step": 10
         }
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Total Counter Events",
       "tooltip": {
@@ -1055,92 +884,11 @@
           "min": null,
           "show": false
         }
-      ]
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
-      "description": "Cumulative number of CounterEvents cached from Cloud Foundry Firehose.",
-      "editable": true,
-      "error": false,
-      "fill": 1,
-      "gridPos": {
-        "h": 5,
-        "w": 6,
-        "x": 12,
-        "y": 10
-      },
-      "id": 17,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": false,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "connected",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "sum(firehose_counter_events_cached{environment=~\"$environment\",instance=~\"$instance\"}) by(instance)",
-          "intervalFactor": 2,
-          "legendFormat": "{{ instance }}",
-          "refId": "A",
-          "step": 10
-        }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Counter Events Cached",
-      "tooltip": {
-        "msResolution": false,
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "transparent": true,
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": false
-        }
-      ]
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "cacheTimeout": null,
@@ -1232,16 +980,18 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "${DS_PROMETHEUS}",
-      "description": "Number of HttpStartStops received and processed per second from Cloud Foundry Firehose during the last 5 minutes.",
+      "description": "Number of Http metrics received and processed per second from Cloud Foundry Firehose during the last 5 minutes.",
       "editable": true,
       "error": false,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 5,
-        "w": 6,
+        "w": 9,
         "x": 0,
         "y": 15
       },
+      "hiddenSeries": false,
       "id": 4,
       "legend": {
         "avg": false,
@@ -1266,24 +1016,19 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(firehose_total_http_start_stop_received{environment=~\"$environment\",instance=~\"$instance\"}[5m])",
+          "expr": "rate(firehose_total_http_metrics_received{environment=~\"$environment\",instance=~\"$instance\"}[5m])",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Received ({{ instance }})",
           "refId": "A",
-          "step": 10
-        },
-        {
-          "expr": "rate(firehose_total_http_start_stop_processed{environment=~\"$environment\",instance=~\"$instance\"}[5m])",
-          "intervalFactor": 2,
-          "legendFormat": "Processed ({{ instance }})",
-          "refId": "B",
           "step": 10
         }
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
-      "title": "Rate HTTP Start Stop per second",
+      "title": "Rate HTTP Metrics per second",
       "tooltip": {
         "msResolution": false,
         "shared": true,
@@ -1316,7 +1061,11 @@
           "min": null,
           "show": false
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -1324,16 +1073,18 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "${DS_PROMETHEUS}",
-      "description": "Cumulative number of HttpStartStops received and processed from Cloud Foundry Firehose.",
+      "description": "Cumulative number of Http metrics received and processed from Cloud Foundry Firehose.",
       "editable": true,
       "error": false,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 5,
-        "w": 6,
-        "x": 6,
+        "w": 9,
+        "x": 9,
         "y": 15
       },
+      "hiddenSeries": false,
       "id": 23,
       "legend": {
         "avg": false,
@@ -1358,24 +1109,19 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(firehose_total_http_start_stop_received{environment=~\"$environment\",instance=~\"$instance\"}) by(instance)",
+          "expr": "sum(firehose_total_http_metrics_received{environment=~\"$environment\",instance=~\"$instance\"}) by(instance)",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "Received ({{ instance }})",
           "refId": "A",
           "step": 10
-        },
-        {
-          "expr": "sum(firehose_total_http_start_stop_processed{environment=~\"$environment\",instance=~\"$instance\"}) by(instance)",
-          "intervalFactor": 2,
-          "legendFormat": "Processed ({{ instance }})",
-          "refId": "B",
-          "step": 10
         }
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
-      "title": "Total HTTP Start Stop",
+      "title": "Total HTTP Metrics",
       "tooltip": {
         "msResolution": false,
         "shared": true,
@@ -1408,92 +1154,11 @@
           "min": null,
           "show": false
         }
-      ]
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
-      "description": "Cumulative number of HttpStartStops cached from Cloud Foundry Firehose.",
-      "editable": true,
-      "error": false,
-      "fill": 1,
-      "gridPos": {
-        "h": 5,
-        "w": 6,
-        "x": 12,
-        "y": 15
-      },
-      "id": 18,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": false,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "connected",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "sum(firehose_http_start_stop_cached{environment=~\"$environment\",instance=~\"$instance\"}) by(instance)",
-          "intervalFactor": 2,
-          "legendFormat": "{{ instance }}",
-          "refId": "A",
-          "step": 10
-        }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "HTTP Start Stop Cached",
-      "tooltip": {
-        "msResolution": false,
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "transparent": true,
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": false
-        }
-      ]
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "cacheTimeout": null,
@@ -1505,7 +1170,7 @@
         "rgba(50, 172, 45, 0.97)"
       ],
       "datasource": "${DS_PROMETHEUS}",
-      "description": "When was the last HttpStartStop received from Cloud Foundry Firehose.",
+      "description": "When was the last Http metrics received from Cloud Foundry Firehose.",
       "editable": true,
       "error": false,
       "format": "s",
@@ -1559,14 +1224,16 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "time() - max(firehose_last_http_start_stop_received_timestamp{environment=~\"$environment\",instance=~\"$instance\"})",
+          "expr": "time() - max(firehose_last_http_metric_received_timestamp{environment=~\"$environment\",instance=~\"$instance\"})",
+          "interval": "",
           "intervalFactor": 2,
+          "legendFormat": "",
           "refId": "A",
           "step": 60
         }
       ],
       "thresholds": "",
-      "title": "Last HTTP Start Stop Received",
+      "title": "Last HTTP Metrics Received",
       "transparent": true,
       "type": "singlestat",
       "valueFontSize": "80%",
@@ -1589,12 +1256,14 @@
       "editable": true,
       "error": false,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 5,
-        "w": 6,
+        "w": 9,
         "x": 0,
         "y": 20
       },
+      "hiddenSeries": false,
       "id": 2,
       "legend": {
         "avg": false,
@@ -1624,18 +1293,11 @@
           "legendFormat": "Received ({{ instance }})",
           "refId": "A",
           "step": 10
-        },
-        {
-          "expr": "rate(firehose_total_value_metrics_processed{environment=~\"$environment\",instance=~\"$instance\"}[5m])",
-          "intervalFactor": 2,
-          "legendFormat": "Processed ({{ instance }})",
-          "metric": "",
-          "refId": "B",
-          "step": 10
         }
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Rate Value Metrics per second",
       "tooltip": {
@@ -1670,7 +1332,11 @@
           "min": null,
           "show": false
         }
-      ]
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "aliasColors": {},
@@ -1682,12 +1348,14 @@
       "editable": true,
       "error": false,
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 5,
-        "w": 6,
-        "x": 6,
+        "w": 9,
+        "x": 9,
         "y": 20
       },
+      "hiddenSeries": false,
       "id": 24,
       "legend": {
         "avg": false,
@@ -1717,18 +1385,11 @@
           "legendFormat": "Received ({{ instance }})",
           "refId": "A",
           "step": 10
-        },
-        {
-          "expr": "sum(firehose_total_value_metrics_processed{environment=~\"$environment\",instance=~\"$instance\"}) by(instance)",
-          "intervalFactor": 2,
-          "legendFormat": "Processed ({{ instance }})",
-          "metric": "",
-          "refId": "B",
-          "step": 10
         }
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "Total Value Metrics",
       "tooltip": {
@@ -1763,92 +1424,11 @@
           "min": null,
           "show": false
         }
-      ]
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "${DS_PROMETHEUS}",
-      "description": "Cumulative number of ValueMetrics cached from Cloud Foundry Firehose.",
-      "editable": true,
-      "error": false,
-      "fill": 1,
-      "gridPos": {
-        "h": 5,
-        "w": 6,
-        "x": 12,
-        "y": 20
-      },
-      "id": 15,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": false,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "connected",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "sum(firehose_value_metrics_cached{environment=~\"$environment\",instance=~\"$instance\"}) by(instance)",
-          "intervalFactor": 2,
-          "legendFormat": "{{ instance }}",
-          "refId": "A",
-          "step": 10
-        }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Value Metrics Cached",
-      "tooltip": {
-        "msResolution": false,
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "transparent": true,
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": false
-        }
-      ]
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
       "cacheTimeout": null,
@@ -1936,7 +1516,7 @@
     }
   ],
   "refresh": "30s",
-  "schemaVersion": 16,
+  "schemaVersion": 26,
   "style": "dark",
   "tags": [
     "prometheus"
@@ -1956,6 +1536,7 @@
         "query": "label_values(firehose_total_envelopes_received, environment)",
         "refresh": 1,
         "regex": "",
+        "skipUrlSync": false,
         "sort": 1,
         "tagValuesQuery": "",
         "tags": [],
@@ -1976,6 +1557,7 @@
         "query": "label_values(firehose_total_envelopes_received{environment=~\"$environment\"}, instance)",
         "refresh": 1,
         "regex": "",
+        "skipUrlSync": false,
         "sort": 1,
         "tagValuesQuery": null,
         "tags": [],
@@ -2017,5 +1599,5 @@
   "timezone": "browser",
   "title": "Prometheus: Cloud Foundry Firehose Exporter",
   "uid": "prometheus_firehose_exporter",
-  "version": 1
+  "version": 2
 }

--- a/jobs/firehose_exporter/spec
+++ b/jobs/firehose_exporter/spec
@@ -8,56 +8,58 @@ templates:
   bin/firehose_exporter_ctl: bin/firehose_exporter_ctl
   config/web_tls_cert.pem: config/web_tls_cert.pem
   config/web_tls_key.pem: config/web_tls_key.pem
+  config/rlp_tls_ca.pem: config/rlp_tls_ca.pem
+  config/rlp_tls_cert.pem: config/rlp_tls_cert.pem
+  config/rlp_tls_key.pem: config/rlp_tls_key.pem
 
 provides:
   - name: firehose_exporter
     type: firehose_exporter
 
+consumes:
+  - name: reverse_log_proxy
+    type: reverse_log_proxy
+    optional: true
+
 properties:
-  firehose_exporter.uaa.url:
-    description: "Cloud Foundry UAA URL"
-  firehose_exporter.uaa.client_id:
-    description: "Cloud Foundry UAA Client ID"
-  firehose_exporter.uaa.client_secret:
-    description: "Cloud Foundry UAA Client Secret"
   firehose_exporter.doppler.subscription_id:
     description: "Cloud Foundry Doppler Subscription ID"
     default: prometheus
-  firehose_exporter.doppler.use_unique_subscription_id:
-    description: "If true the instance id will be added as a suffix to the subscription id"
-    default: false
-  firehose_exporter.doppler.idle_timeout:
-    description: "Cloud Foundry Doppler Idle Timeout"
-  firehose_exporter.doppler.min_retry_delay:
-    description: "Cloud Foundry Doppler min retry delay duration"
-  firehose_exporter.doppler.max_retry_delay:
-    description: "Cloud Foundry Doppler max retry delay duration"
-  firehose_exporter.doppler.max_retry_count:
-    description: "Cloud Foundry Doppler max retry count"
   firehose_exporter.doppler.metric_expiration:
-    description: "How long a Cloud Foundry Doppler metric is valid"
-  firehose_exporter.filter.deployments:
-    description: "Comma separated deployments to filter"
-  firehose_exporter.filter.events:
-    description: "Comma separated events to filter (ContainerMetric, CounterEvent, HttpStartStop, ValueMetric)"
+    description: "How long a Cloud Foundry metric is valid"
   firehose_exporter.logging.url:
     description: "Cloud Foundry Logging endpoint"
-  firehose_exporter.logging.use_legacy_firehose:
-    description: "Whether to use the v1 firehose rather than the RLP"
+    default: ""
+  firehose_exporter.logging.tls.ca:
+    description: "Ca cert to connect to rlp"
+    default: ""
+  firehose_exporter.logging.tls.cert:
+    description: "Cert to connect to rlp in mtls auth"
+    default: ""
+  firehose_exporter.logging.tls.key:
+    description: "Key to connect to rlp in mtls auth"
+    default: ""
+  firehose_exporter.log_in_json:
+    description: "Set the log in json format"
     default: false
-  firehose_exporter.log_format:
-    description: "Set the log target and format. Example: 'logger:syslog?appname=bob&local=7' or 'logger:stdout?json=true'"
   firehose_exporter.log_level:
     description: "Only log messages with the given severity or above. Valid levels: [debug, info, warn, error, fatal]"
   firehose_exporter.metrics.namespace:
     description: "Metrics Namespace"
   firehose_exporter.metrics.environment:
     description: "Environment label to be attached to metrics"
-  firehose_exporter.metrics.cleanup_interval:
-    description: "Metrics clean up interval"
+  firehose_exporter.metrics.timer_rollup_buffer_size:
+    description: "The number of envelopes that will be allowed to be buffered while timer metric aggregations are running"
+    default: 16384
   firehose_exporter.skip_ssl_verify:
     description: "Disable SSL Verify"
     default: false
+
+  firehose_exporter.filter.deployments:
+    description: "Comma separated deployments to filter"
+  firehose_exporter.filter.events:
+    description: "Comma separated events to filter (ContainerMetric, CounterEvent, Http, ValueMetric)"
+
   firehose_exporter.web.port:
     description: "Port on which to expose web interface and telemetry"
     default: "9186"
@@ -71,6 +73,16 @@ properties:
     description: "TLS certificate (PEM format). If the certificate is signed by a certificate authority, the file should be the concatenation of the server's certificate, any intermediates, and the CA's certificate"
   firehose_exporter.web.tls_key:
     description: "TLS private key (PEM format)"
+  firehose_exporter.retro_compat.disable:
+    description: "Disable retro compatibility"
+    default: false
+  firehose_exporter.retro_compat.enable_delta:
+    description: "Enable retro compatibility delta in counter"
+    default: false
+
+  firehose_exporter.profiler.enable:
+    description: "Enable pprof profiling on app on /debug/pprof"
+    default: false
 
   env.http_proxy:
     description: "HTTP proxy to use"

--- a/jobs/firehose_exporter/templates/bin/firehose_exporter_ctl
+++ b/jobs/firehose_exporter/templates/bin/firehose_exporter_ctl
@@ -34,46 +34,25 @@ case $1 in
     export no_proxy="<%= no_proxy %>"
     <% end %>
 
-    export FIREHOSE_EXPORTER_UAA_CLIENT_SECRET="<%= p('firehose_exporter.uaa.client_secret') %>"
     <% if_p('firehose_exporter.web.auth_password') do |auth_password| %>
     export FIREHOSE_EXPORTER_WEB_AUTH_PASSWORD="<%= auth_password %>"
     <% end %>
+    export GODEBUG="x509ignoreCN=0" # temporary (15Sep2020) while we wait for upstream (firehose) certs to be updated
 
     exec firehose_exporter \
-      --uaa.url="<%= p('firehose_exporter.uaa.url') %>" \
-      --uaa.client-id="<%= p('firehose_exporter.uaa.client_id') %>" \
-      <% if p('firehose_exporter.doppler.use_unique_subscription_id') %> \
-      --doppler.subscription-id="<%= "#{p('firehose_exporter.doppler.subscription_id')}-#{spec.id}" %>" \
-      <% else %> \
-      --doppler.subscription-id="<%= p('firehose_exporter.doppler.subscription_id') %>" \
-      <% end %> \
-      <% if_p('firehose_exporter.doppler.idle_timeout') do |idle_timeout| %> \
-      --doppler.idle-timeout="<%= idle_timeout %>" \
-      <% end %> \
-      <% if_p('firehose_exporter.doppler.min_retry_delay') do |min_retry_delay| %> \
-      --doppler.min-retry-delay="<%= min_retry_delay %>" \
-      <% end %> \
-      <% if_p('firehose_exporter.doppler.max_retry_delay') do |max_retry_delay| %> \
-      --doppler.max-retry-delay="<%= max_retry_delay %>" \
-      <% end %> \
-      <% if_p('firehose_exporter.doppler.max_retry_count') do |max_retry_count| %> \
-      --doppler.max-retry-count="<%= max_retry_count %>" \
-      <% end %> \
+      --metrics.shard_id="<%= p('firehose_exporter.doppler.subscription_id') %>" \
       <% if_p('firehose_exporter.doppler.metric_expiration') do |metric_expiration| %> \
-      --doppler.metric-expiration="<%= metric_expiration %>" \
+      --metrics.expiration="<%= metric_expiration %>" \
       <% end %> \
-      <% if_p('firehose_exporter.filter.deployments') do |deployments| %> \
-      --filter.deployments="<%= deployments %>" \
+      --metrics.node_index="<%= spec.index %>" \
+      <% if_link('reverse_log_proxy') do |rlp| %> \
+      --logging.url="<%= "#{rlp.address}:#{rlp.p('reverse_log_proxy.egress.port')}" %>" \
+      --logging.tls.ca="/var/vcap/jobs/firehose_exporter/config/rlp_tls_ca.pem" \
+      --logging.tls.cert="/var/vcap/jobs/firehose_exporter/config/rlp_tls_cert.pem" \
+      --logging.tls.key="/var/vcap/jobs/firehose_exporter/config/rlp_tls_key.pem" \
       <% end %> \
-      <% if_p('firehose_exporter.filter.events') do |events| %> \
-      --filter.events="<%= events %>" \
-      <% end %> \
-      --logging.url="<%= p('firehose_exporter.logging.url') %>" \
-      <% if p('firehose_exporter.logging.use_legacy_firehose') %> \
-      --logging.use-legacy-firehose \
-      <% end %> \
-      <% if_p('firehose_exporter.log_format') do |log_format| %> \
-      --log.format="<%= log_format %>" \
+      <% if_p('firehose_exporter.log_in_json') do |log_in_json| %> \
+      --log.in_json \
       <% end %> \
       <% if_p('firehose_exporter.log_level') do |log_level| %> \
       --log.level="<%= log_level %>" \
@@ -82,11 +61,15 @@ case $1 in
       --metrics.namespace="<%= namespace %>" \
       <% end %> \
       --metrics.environment="<%= p('firehose_exporter.metrics.environment') %>" \
-      <% if_p('firehose_exporter.metrics.cleanup_interval') do |cleanup_interval| %> \
-      --metrics.cleanup-interval="<%= cleanup_interval %>" \
-      <% end %> \
+      --metrics.timer_rollup_buffer_size="<%= p('firehose_exporter.metrics.timer_rollup_buffer_size') %>" \
       <% if p('firehose_exporter.skip_ssl_verify') %> \
       --skip-ssl-verify \
+      <% end %> \
+      <% if_p('firehose_exporter.filter.deployments') do |deployments| %> \
+      --filter.deployments="<%= deployments %>" \
+      <% end %> \
+      <% if_p('firehose_exporter.filter.events') do |events| %> \
+      --filter.events="<%= events %>" \
       <% end %> \
       --web.listen-address=":<%= p('firehose_exporter.web.port') %>" \
       <% if_p('firehose_exporter.web.telemetry_path') do |telemetry_path| %> \
@@ -98,6 +81,15 @@ case $1 in
       <% if_p('firehose_exporter.web.tls_cert', 'firehosef_exporter.web.tls_key') do %> \
       --web.tls.cert_file="/var/vcap/jobs/firehose_exporter/config/web_tls_cert.pem" \
       --web.tls.key_file="/var/vcap/jobs/firehose_exporter/config/web_tls_key.pem" \
+      <% end %> \
+      <% if p('firehose_exporter.retro_compat.disable') %> \
+      --retro_compat.disable \
+      <% end %> \
+      <% if p('firehose_exporter.retro_compat.enable_delta') %> \
+      --retro_compat.enable_delta \
+      <% end %> \
+      <% if_p('firehose_exporter.profiler.enable') do |profiler_enable| %> \
+      --profiler.enable \
       <% end %> \
       >>  ${LOG_DIR}/firehose_exporter.stdout.log \
       2>> ${LOG_DIR}/firehose_exporter.stderr.log

--- a/jobs/firehose_exporter/templates/config/rlp_tls_ca.pem
+++ b/jobs/firehose_exporter/templates/config/rlp_tls_ca.pem
@@ -1,0 +1,1 @@
+<%= p('firehose_exporter.logging.tls.ca', '') %>

--- a/jobs/firehose_exporter/templates/config/rlp_tls_cert.pem
+++ b/jobs/firehose_exporter/templates/config/rlp_tls_cert.pem
@@ -1,0 +1,1 @@
+<%= p('firehose_exporter.logging.tls.cert', '') %>

--- a/jobs/firehose_exporter/templates/config/rlp_tls_key.pem
+++ b/jobs/firehose_exporter/templates/config/rlp_tls_key.pem
@@ -1,0 +1,1 @@
+<%= p('firehose_exporter.logging.tls.key', '') %>

--- a/manifests/operators/cf/add-prometheus-uaa-clients.yml
+++ b/manifests/operators/cf/add-prometheus-uaa-clients.yml
@@ -16,18 +16,3 @@
     name: uaa_clients_cf_exporter_secret
     type: password
 
-# UAA client for firehose_exporter
-- type: replace
-  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/firehose_exporter?
-  value:
-    override: true
-    authorized-grant-types: client_credentials,refresh_token
-    authorities: doppler.firehose
-    scope: openid,doppler.firehose
-    secret: "((uaa_clients_firehose_exporter_secret))"
-
-- type: replace
-  path: /variables/-
-  value:
-    name: uaa_clients_firehose_exporter_secret
-    type: password

--- a/manifests/operators/enable-cf-loggregator-v2.yml
+++ b/manifests/operators/enable-cf-loggregator-v2.yml
@@ -1,9 +1,0 @@
-# This file assumes firehose_exporter is being used: ./monitor-cf.yml
-
-- type: replace
-  path: /instance_groups/name=firehose/jobs/name=firehose_exporter/properties/firehose_exporter/logging/url?
-  value: https://log-stream.((system_domain))
-
-- type: replace
-  path: /instance_groups/name=firehose/jobs/name=firehose_exporter/properties/firehose_exporter/logging/use_legacy_firehose?
-  value: false

--- a/manifests/operators/monitor-cf.yml
+++ b/manifests/operators/monitor-cf.yml
@@ -32,21 +32,34 @@
     jobs:
       - name: firehose_exporter
         release: prometheus
+        consumes:
+          reverse_log_proxy:
+            deployment: cf
+            from: reverse_log_proxy
         properties:
           firehose_exporter:
             doppler:
               subscription_id: "((metrics_environment))"
-              max_retry_count: 300
             logging:
-              url: wss://doppler.((system_domain)):((traffic_controller_external_port))
-              use_legacy_firehose: true
-            uaa:
-              url: https://uaa.((system_domain))
-              client_id: firehose_exporter
-              client_secret: "((uaa_clients_firehose_exporter_secret))"
+              tls:
+                ca: ((firehose_exporter_to_logs_provider.ca))
+                cert: ((firehose_exporter_to_logs_provider.certificate))
+                key: ((firehose_exporter_to_logs_provider.private_key))
             metrics:
               environment: "((metrics_environment))"
             skip_ssl_verify: ((skip_ssl_verify))
+
+- type: replace
+  path: /variables/-
+  value:
+    name: firehose_exporter_to_logs_provider
+    options:
+      ca: ((loggregator_ca_name)) # generally set it to /bosh-((name))/cf/loggregator_ca
+      common_name: firehose-exporter
+      extended_key_usage:
+        - client_auth
+        - server_auth
+    type: certificate
 
 # Prometheus Alerts
 - type: replace


### PR DESCRIPTION
This PR is associated to PR https://github.com/bosh-prometheus/firehose_exporter/pull/63 on firehose_exporter.
Please see this pull request for more context.

Here, it will only change dashboards consequently to the change of http_start_stop, set correct `ctl` for new firehose exporter and fix previous operator for firehose.

Dashboard latency include new panels which look like this a the end:

<img width="2938" alt="Capture d’écran 2021-03-29 à 11 37 38" src="https://user-images.githubusercontent.com/5410858/112817876-36d55c00-9083-11eb-9f19-5e99d9eb02ff.png">
