### PR TITLE
adjust default value of credhub_alerts.scrape_too_old.threshold

### DIFF
--- a/jobs/credhub_alerts/spec
+++ b/jobs/credhub_alerts/spec
@@ -25,7 +25,7 @@ properties:
     default: 10m
   credhub_alerts.scrape_too_old.threshold:
     description: "Scrape too old alert threshold (in seconds)"
-    default: 3600
+    default: 21600
   credhub_alerts.scrape_error.evaluation_time:
     description: "Scrape error alert evaluation time"
     default: 10m


### PR DESCRIPTION
The currently used version of the credhub_exporter uses 6h as the default
scraping interval [1,2]. This commit adjusts the default value of
scrape_too_old for credhub_alerts to 6h, in order to not throw any
alerts for a default deployment.

[1] https://github.com/orange-cloudfoundry/credhub_exporter/blob/v0.2.2/README.md#flags
[2] https://github.com/orange-cloudfoundry/credhub_exporter/blob/v0.2.2/credhub_exporter.go#L65