### PR TITLE
[grafana] Add timeout to nc to prevent it from freezing for bionic st…

### DIFF
--- a/jobs/grafana/templates/bin/grafana-admin-password
+++ b/jobs/grafana/templates/bin/grafana-admin-password
@@ -5,7 +5,7 @@ set -eu
 retries=60
 for ((i=0; i<=retries; i++)); do
   echo "Waiting for grafana to listen on port <%= p('grafana.server.http_port') %> ($i/$retries)"
-  if nc 127.0.0.1 <%= p('grafana.server.http_port') %> < /dev/null; then
+  if nc  -w 5 127.0.0.1 <%= p('grafana.server.http_port') %> < /dev/null; then
     echo "Grafana is ready"
     break
   fi


### PR DESCRIPTION
…emcell

By adding a timeout with the `-w` option we prevent nc from never returning on bionic stemcells. 

Fixes #416. 