### PR TITLE
Switch from Xenial to Bionic Stemcells

### DIFF
--- a/manifests/prometheus.yml
+++ b/manifests/prometheus.yml
@@ -163,7 +163,7 @@ update:
 
 stemcells:
   - alias: default
-    os: ubuntu-xenial
+    os: ubuntu-bionic
     version: latest
 
 releases:


### PR DESCRIPTION
Closes #418 

As Bionic Stemcells are GA now, we should switch to use them. 