### PR TITLE
prometheus 2.22.2 to 2.26.1

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -146,10 +146,9 @@ prometheus/prometheus-1.8.2.linux-amd64.tar.gz:
   size: 17748716
   object_id: 54fd8c7b-a676-44cd-64b2-d5788552e607
   sha: 33101ac86a6376680c3b44b63db47f1754d77a1a
-prometheus/prometheus-2.22.2.linux-amd64.tar.gz:
-  size: 64017057
-  object_id: e3d509f3-ccd2-421b-65bb-34992b7ae7b7
-  sha: sha256:acd3189c3f09b3857b6635df327814633939be07d12c4eea8f78c94fe9fd115c
+prometheus/prometheus-2.26.1.linux-amd64.tar.gz:
+  size: 65179092
+  sha: sha256:fe16026d37a69ac195176096d3629ac6b3d1b553b5d9f0bd723b607a8b311707
 pushgateway/pushgateway-1.3.0.linux-amd64.tar.gz:
   size: 9061204
   object_id: 851df208-d52b-42d1-6931-f557f017c1cd

--- a/packages/prometheus2/packaging
+++ b/packages/prometheus2/packaging
@@ -8,5 +8,5 @@ cp -a ${BOSH_COMPILE_TARGET}/common/* ${BOSH_INSTALL_TARGET}/common
 
 # Extract prometheus package
 mkdir -p ${BOSH_INSTALL_TARGET}/bin
-tar xzvf ${BOSH_COMPILE_TARGET}/prometheus/prometheus-2.22.2.linux-amd64.tar.gz
-cp -a ${BOSH_COMPILE_TARGET}/prometheus-2.22.2.linux-amd64/* ${BOSH_INSTALL_TARGET}/bin
+tar xzvf ${BOSH_COMPILE_TARGET}/prometheus/prometheus-2.26.1.linux-amd64.tar.gz
+cp -a ${BOSH_COMPILE_TARGET}/prometheus-2.26.1.linux-amd64/* ${BOSH_INSTALL_TARGET}/bin

--- a/packages/prometheus2/spec
+++ b/packages/prometheus2/spec
@@ -3,4 +3,4 @@ name: prometheus2
 
 files:
   - common/utils.sh
-  - prometheus/prometheus-2.22.2.linux-amd64.tar.gz
+  - prometheus/prometheus-2.26.1.linux-amd64.tar.gz


### PR DESCRIPTION
In order to leverage more efficient versions of prometheus, this PR bumps from prometheus 2.22.2 to the latest of 2.26.1.

I have tested this on my private environment and haven't experienced problems.

Blobs: if accepted, blobs will need to be stored and uploaded into the blobstore:

```
wget https://github.com/prometheus/prometheus/releases/download/v2.26.1/prometheus-2.26.1.linux-amd64.tar.gz
bosh add-blob prometheus-2.26.1.linux-amd64.tar.gz prometheus/prometheus-2.26.1.linux-amd64.tar.gz
bosh remove-blob prometheus/prometheus-2.22.2.linux-amd64.tar.gz  test
Removed blob 'prometheus/prometheus-2.22.2.linux-amd64.tar.gz
```

This is my first PR, so sorry if I'm wrong.