### PR TITLE
bump credhub_exporter to v0.3.0

### DIFF
--- a/jobs/credhub_exporter/spec
+++ b/jobs/credhub_exporter/spec
@@ -42,9 +42,9 @@ properties:
     description: "Fetch credentials whose name contains the query string (fetch all credentials when empty)"
   credhub_exporter.filters.path:
     description: "Fetch credentials that exist under the provided path"
-  credhub_exporter.log_format:
-    description: "Set the log target and format. Example: 'logger:syslog?appname=bob&local=7' or 'logger:stdout?json=true'"
-    default: logger:stderr
+  credhub_exporter.log_stream:
+    description: "Set the log target stream 'stdout' or 'stderr'"
+    default: stderr
   credhub_exporter.log_level:
     description: "Only log messages with the given severity or above. Valid levels: [debug, info, warn, error, fatal]"
     default: info

--- a/jobs/credhub_exporter/templates/bpm.yml.erb
+++ b/jobs/credhub_exporter/templates/bpm.yml.erb
@@ -13,7 +13,7 @@ end
 
 args = [
   "--log.level",  p("credhub_exporter.log_level"),
-  "--log.format", p("credhub_exporter.log_format"),
+  "--log.stream", p("credhub_exporter.log_stream"),
 ]
 
 env = {}

--- a/packages/credhub_exporter/packaging
+++ b/packages/credhub_exporter/packaging
@@ -3,4 +3,4 @@
 set -eux
 
 mkdir -p ${BOSH_INSTALL_TARGET}/bin
-tar zxf credhub_exporter/credhub_exporter_0.2.2_linux_amd64.tar.gz --strip 1 -C ${BOSH_INSTALL_TARGET}/bin
+tar zxf credhub_exporter/credhub_exporter_0.3.0_linux_amd64.tar.gz --strip 1 -C ${BOSH_INSTALL_TARGET}/bin

--- a/packages/credhub_exporter/spec
+++ b/packages/credhub_exporter/spec
@@ -2,6 +2,6 @@
 name: credhub_exporter
 
 files:
-  - credhub_exporter/credhub_exporter_0.2.2_linux_amd64.tar.gz
+  - credhub_exporter/credhub_exporter_0.3.0_linux_amd64.tar.gz
 
 


### PR DESCRIPTION
This PR bumps credhub_exporter from `v0.2.0` to `v0.3.0`.

**Changelog**
- credhub_exporter: 
  - bump internal golang dependencies
  - replaced `github.com/prometheus/common/log` by `github.com/sirupsen/logrus` as log facility
  - add `--log.level`, `--log.stream` and `log.json` command line flags
- bosh spec changes
  - remove `credhub_exporter.log_format` 
  - replaced by `credhub_exporter.log_stream` (default `stderr`)

**Blobs**

```
# fetch credhub exporter new release
wget https://github.com/orange-cloudfoundry/credhub_exporter/releases/download/v0.3.0/credhub_exporter_0.3.0_linux_amd64.tar.gz
# add tarball to blobs
bosh add-blob credhub_exporter_0.3.0_linux_amd64.tar.gz credhub_exporter/credhub_exporter_0.3.0_linux_amd64.tar.gz
# remove old blob
bosh remove-blob credhub_exporter/credhub_exporter_0.2.2_linux_amd64.tar.gz
```
