### PR TITLE
add mute_time_intervals properties to alertmanager

### DIFF
--- a/jobs/alertmanager/spec
+++ b/jobs/alertmanager/spec
@@ -136,8 +136,6 @@ properties:
     description: "A set of equality matchers an alert has to fulfill to match the node"
   alertmanager.route.match_re:
     description: "A set of regex-matchers an alert has to fulfill to match the node"
-  alertmanager.route.mute_time_intervals:
-    description: "Times when the route should be muted"
   alertmanager.route.routes:
     description: "Child routes"
 

--- a/jobs/alertmanager/spec
+++ b/jobs/alertmanager/spec
@@ -135,9 +135,9 @@ properties:
   alertmanager.route.match:
     description: "A set of equality matchers an alert has to fulfill to match the node"
   alertmanager.route.match_re:
-    description: A set of regex-matchers an alert has to fulfill to match the node
+    description: "A set of regex-matchers an alert has to fulfill to match the node"
   alertmanager.route.mute_time_intervals:
-    description: Times when the route should be muted
+    description: "Times when the route should be muted"
   alertmanager.route.routes:
     description: "Child routes"
 

--- a/jobs/alertmanager/spec
+++ b/jobs/alertmanager/spec
@@ -136,6 +136,8 @@ properties:
     description: "A set of equality matchers an alert has to fulfill to match the node"
   alertmanager.route.match_re:
     description: A set of regex-matchers an alert has to fulfill to match the node
+  alertmanager.route.mute_time_intervals:
+    description: Times when the route should be muted
   alertmanager.route.routes:
     description: "Child routes"
 
@@ -144,6 +146,9 @@ properties:
 
   alertmanager.inhibit_rules:
     description: "Inhibition rules"
+
+  alertmanager.mute_time_intervals:
+    description: "Mute time intervals"
 
   alertmanager.test_alert.hourly:
     description: "Send a test alert hourly?"

--- a/jobs/alertmanager/templates/config/alertmanager.yml
+++ b/jobs/alertmanager/templates/config/alertmanager.yml
@@ -113,6 +113,8 @@ route:
   match_re: <%= match_re %>
   <% end %>
 
+  mute_time_intervals: <%= p('alertmanager.route.mute_time_intervals', []).to_json %>
+
   # Child routes
   routes: <%= p('alertmanager.route.routes', []).to_json %>
 
@@ -122,4 +124,9 @@ receivers: <%= p('alertmanager.receivers').to_json %>
 <% if_p('alertmanager.inhibit_rules') do |inhibit_rules| %>
 # A list of inhibition rules
 inhibit_rules: <%= inhibit_rules.to_json %>
+<% end %>
+
+<% if_p('alertmanager.mute_time_intervals') do |mute_time_intervals| %>
+# A list of mute time intervals for muting routes.
+mute_time_intervals: <%= mute_time_intervals.to_json %>
 <% end %>

--- a/jobs/alertmanager/templates/config/alertmanager.yml
+++ b/jobs/alertmanager/templates/config/alertmanager.yml
@@ -113,8 +113,6 @@ route:
   match_re: <%= match_re %>
   <% end %>
 
-  mute_time_intervals: <%= p('alertmanager.route.mute_time_intervals', []).to_json %>
-
   # Child routes
   routes: <%= p('alertmanager.route.routes', []).to_json %>
 


### PR DESCRIPTION
I added mute_time_interval properties to alertmanager.

Mute time interval is a config option of alertmanager for muting alerts in specify times. It can be configured in alertmanager 0.21 or later.
https://prometheus.io/docs/alerting/latest/configuration/#mute_time_interval