### PR TITLE
Add missing features and fix bugs

### DIFF
--- a/jobs/alertmanager/spec
+++ b/jobs/alertmanager/spec
@@ -63,6 +63,8 @@ properties:
     description: "The URL under which Alertmanager is externally reachable"
   alertmanager.web.get_concurrency:
     description: "Maximum number of GET requests processed concurrently. If negative or zero, the limit is GOMAXPROC or 8, whichever is larger"
+  alertmanager.web.listen_address:
+    description: "Address to listen on for the web interface and API"
   alertmanager.web.port:
     description: "Port to listen on for the web interface and API"
     default: "9093"

--- a/jobs/alertmanager/spec
+++ b/jobs/alertmanager/spec
@@ -135,7 +135,11 @@ properties:
   alertmanager.route.match:
     description: "A set of equality matchers an alert has to fulfill to match the node"
   alertmanager.route.match_re:
-    description: A set of regex-matchers an alert has to fulfill to match the node
+    description: "A set of regex-matchers an alert has to fulfill to match the node"
+  alertmanager.route.matchers:
+    description: "A list of matchers that an alert has to fulfill to match the node."
+  alertmanager.route.mute_time_intervals:
+    description: "A list of mute time intervals for muting routes."
   alertmanager.route.routes:
     description: "Child routes"
 
@@ -144,6 +148,9 @@ properties:
 
   alertmanager.inhibit_rules:
     description: "Inhibition rules"
+
+  alertmanager.mute_time_intervals:
+    description: "Mute time intervals for muting routes."
 
   alertmanager.test_alert.hourly:
     description: "Send a test alert hourly?"

--- a/jobs/alertmanager/spec
+++ b/jobs/alertmanager/spec
@@ -33,7 +33,7 @@ properties:
   alertmanager.log_format:
     description: "Output format of log messages. One of: [logfmt, json]"
   alertmanager.cluster.listen_address:
-    description: "Cluster listen address . By default use IP computed by BOSH spec"
+    description: "Cluster listen address. By default use IP computed by BOSH spec"
   alertmanager.cluster.advertise_address:
     description: "Cluster advertise address"
   alertmanager.cluster.gossip_interval:
@@ -64,7 +64,7 @@ properties:
   alertmanager.web.get_concurrency:
     description: "Maximum number of GET requests processed concurrently. If negative or zero, the limit is GOMAXPROC or 8, whichever is larger"
   alertmanager.web.listen_address:
-    description: "Address to listen on for the web interface and API"
+    description: "Address to listen on for the web interface and API. It defaults to '', which listens at [::] or 0.0.0.0."
   alertmanager.web.port:
     description: "Port to listen on for the web interface and API"
     default: "9093"

--- a/jobs/alertmanager/spec
+++ b/jobs/alertmanager/spec
@@ -140,8 +140,6 @@ properties:
     description: "A set of regex-matchers an alert has to fulfill to match the node"
   alertmanager.route.matchers:
     description: "A list of matchers that an alert has to fulfill to match the node."
-  alertmanager.route.mute_time_intervals:
-    description: "A list of mute time intervals for muting routes."
   alertmanager.route.routes:
     description: "Child routes"
 

--- a/jobs/alertmanager/templates/bin/alertmanager_ctl
+++ b/jobs/alertmanager/templates/bin/alertmanager_ctl
@@ -86,7 +86,7 @@ case $1 in
       <% if_p('alertmanager.web.external_url') do |external_url| %> \
       --web.external-url="<%= external_url %>" \
       <% end %> \
-      --web.listen-address=":<%= p('alertmanager.web.port') %>" \
+      --web.listen-address="<%= p('alertmanager.web.listen_address', '') %>:<%= p('alertmanager.web.port') %>" \
       <% if_p('alertmanager.web.get_concurrency') do |get_concurrency| %> \
       --web.get-concurrency="<%= get_concurrency %>" \
       <% end %> \

--- a/jobs/alertmanager/templates/config/alertmanager.yml
+++ b/jobs/alertmanager/templates/config/alertmanager.yml
@@ -113,6 +113,14 @@ route:
   match_re: <%= match_re.to_json %>
   <% end %>
 
+  <% if_p('alertmanager.route.matchers') do |matchers| %>
+  matchers: <%= matchers.to_json %>
+  <% end %>
+
+  <% if_p('alertmanager.route.mute_time_intervals') do |mute_time_intervals| %>
+  mute_time_intervals: <%= mute_time_intervals.to_json %>
+  <% end %>
+
   # Child routes
   routes: <%= p('alertmanager.route.routes', []).to_json %>
 
@@ -122,4 +130,9 @@ receivers: <%= p('alertmanager.receivers').to_json %>
 <% if_p('alertmanager.inhibit_rules') do |inhibit_rules| %>
 # A list of inhibition rules
 inhibit_rules: <%= inhibit_rules.to_json %>
+<% end %>
+
+<% if_p('alertmanager.mute_time_intervals') do |mute_time_intervals| %>
+# A list of mute time intervals
+mute_time_intervals: <%= mute_time_intervals.to_json %>
 <% end %>

--- a/jobs/alertmanager/templates/config/alertmanager.yml
+++ b/jobs/alertmanager/templates/config/alertmanager.yml
@@ -106,11 +106,11 @@ route:
   <% end %>
 
   <% if_p('alertmanager.route.match') do |match| %>
-  match: <%= match %>
+  match: <%= match.to_json %>
   <% end %>
 
   <% if_p('alertmanager.route.match_re') do |match_re| %>
-  match_re: <%= match_re %>
+  match_re: <%= match_re.to_json %>
   <% end %>
 
   # Child routes

--- a/jobs/alertmanager/templates/config/alertmanager.yml
+++ b/jobs/alertmanager/templates/config/alertmanager.yml
@@ -93,7 +93,7 @@ route:
   group_by: <%= group_by %>
   <% end %>
 
-  <% if_p('alertmanager.route.group_wait') do |group_by| %>
+  <% if_p('alertmanager.route.group_wait') do |group_wait| %>
   group_wait: <%= group_wait %>
   <% end %>
 

--- a/jobs/alertmanager/templates/config/alertmanager.yml
+++ b/jobs/alertmanager/templates/config/alertmanager.yml
@@ -94,7 +94,7 @@ route:
   <% end %>
 
   <% if_p('alertmanager.route.group_wait') do |group_by| %>
-  group_wait: <%= group_by %>
+  group_wait: <%= group_wait %>
   <% end %>
 
   <% if_p('alertmanager.route.group_interval') do |group_interval| %>

--- a/jobs/alertmanager/templates/config/alertmanager.yml
+++ b/jobs/alertmanager/templates/config/alertmanager.yml
@@ -117,10 +117,6 @@ route:
   matchers: <%= matchers.to_json %>
   <% end %>
 
-  <% if_p('alertmanager.route.mute_time_intervals') do |mute_time_intervals| %>
-  mute_time_intervals: <%= mute_time_intervals.to_json %>
-  <% end %>
-
   # Child routes
   routes: <%= p('alertmanager.route.routes', []).to_json %>
 

--- a/jobs/grafana/spec
+++ b/jobs/grafana/spec
@@ -438,7 +438,7 @@ properties:
     description: "Generic OAuth allowed domains"
   grafana.auth.generic_oauth.team_ids:
     description: "Generic OAuth team ids"
-  grafana.auth.generic_oauth.allowed_domains:
+  grafana.auth.generic_oauth.allowed_organizations:
     description: "Generic OAuth allowed organizations"
   grafana.auth.generic_oauth.tls_client_ca:
     description: "Generic OAuth TLS Client CA"

--- a/jobs/nginx/spec
+++ b/jobs/nginx/spec
@@ -94,6 +94,8 @@ properties:
   nginx.alertmanager.server_name:
     description: "Server name that proxy will listen on for Alertmanager HTTP(S) connections"
     default: _
+  nginx.alertmanager.upstream_port:
+    description: "Port that proxy will connect to for Alertmanager connections"
   nginx.alertmanager.http_port:
     description: "Port that proxy will listen on for Alertmanager HTTP connections"
     default: 9093
@@ -120,6 +122,8 @@ properties:
   nginx.grafana.server_name:
     description: "Server name that proxy will listen on for Grafana HTTP(S) connections"
     default: _
+  nginx.grafana.upstream_port:
+    description: "Port that proxy will connect to for Grafana connections"
   nginx.grafana.http_port:
     description: "Port that proxy will listen on for Grafana HTTP connections"
     default: 3000
@@ -146,6 +150,8 @@ properties:
   nginx.prometheus.server_name:
     description: "Server name that proxy will listen on for Prometheus HTTP(S) connections"
     default: _
+  nginx.prometheus.upstream_port:
+    description: "Port that proxy will connect to for Prometheus connections"
   nginx.prometheus.http_port:
     description: "Port that proxy will listen on for Prometheus HTTP connections"
     default: 9090

--- a/jobs/nginx/spec
+++ b/jobs/nginx/spec
@@ -102,6 +102,9 @@ properties:
   nginx.alertmanager.https_port:
     description: "Port that proxy will listen on for Alertmanager HTTPS connections"
     default: 19093
+  nginx.alertmanager.https_redirect_url:
+    description: "Redirect URL when redirecting Alertmanager HTTP connections"
+    default: "https://$host$request_uri"
   nginx.alertmanager.path:
     description: "Alertmanager path"
     default: "/"
@@ -130,6 +133,9 @@ properties:
   nginx.grafana.https_port:
     description: "Port that proxy will listen on for Grafana HTTPS connections"
     default: 13000
+  nginx.grafana.https_redirect_url:
+    description: "Redirect URL when redirecting Grafana HTTP connections"
+    default: "https://$host$request_uri"
   nginx.grafana.path:
     description: "Grafana path"
     default: "/"
@@ -158,6 +164,9 @@ properties:
   nginx.prometheus.https_port:
     description: "Port that proxy will listen on for Prometheus HTTPS connections"
     default: 19090
+  nginx.prometheus.https_redirect_url:
+    description: "Redirect URL when redirecting Prometheus HTTP connections"
+    default: "https://$host$request_uri"
   nginx.prometheus.path:
     description: "Prometheus path"
     default: "/"

--- a/jobs/nginx/spec
+++ b/jobs/nginx/spec
@@ -94,8 +94,6 @@ properties:
   nginx.alertmanager.server_name:
     description: "Server name that proxy will listen on for Alertmanager HTTP(S) connections"
     default: _
-  nginx.alertmanager.upstream_port:
-    description: "Port that proxy will connect to for Alertmanager connections"
   nginx.alertmanager.http_port:
     description: "Port that proxy will listen on for Alertmanager HTTP connections"
     default: 9093
@@ -125,8 +123,6 @@ properties:
   nginx.grafana.server_name:
     description: "Server name that proxy will listen on for Grafana HTTP(S) connections"
     default: _
-  nginx.grafana.upstream_port:
-    description: "Port that proxy will connect to for Grafana connections"
   nginx.grafana.http_port:
     description: "Port that proxy will listen on for Grafana HTTP connections"
     default: 3000
@@ -156,8 +152,6 @@ properties:
   nginx.prometheus.server_name:
     description: "Server name that proxy will listen on for Prometheus HTTP(S) connections"
     default: _
-  nginx.prometheus.upstream_port:
-    description: "Port that proxy will connect to for Prometheus connections"
   nginx.prometheus.http_port:
     description: "Port that proxy will listen on for Prometheus HTTP connections"
     default: 9090

--- a/jobs/nginx/templates/config/nginx.conf
+++ b/jobs/nginx/templates/config/nginx.conf
@@ -28,7 +28,7 @@ http {
   <% if_p('nginx.large_client_header_buffers.number', 'nginx.large_client_header_buffers.size') do |number, size| %>
   large_client_header_buffers <%= number %> <%= size %>;
   <% end %>
-  
+
   types_hash_max_size 2048;
 
   send_timeout 2;
@@ -68,7 +68,7 @@ http {
   upstream alertmanager {
     <% alertmanager.instances.map do |instance| %>
       <% if p('nginx.alertmanager.cross_zone_load_balancing') || instance.az == spec.az %>
-      server <%= "#{instance.address}:#{alertmanager.p('alertmanager.web.port')} fail_timeout=0;" %>
+      server <%= "#{instance.address}:#{p('nginx.alertmanager.upstream_port', alertmanager.p('alertmanager.web.port'))} fail_timeout=0;" %>
       <% end %>
     <% end %>
   }
@@ -120,7 +120,7 @@ http {
   upstream grafana {
     <% grafana.instances.map do |instance| %>
       <% if p('nginx.grafana.cross_zone_load_balancing') || instance.az == spec.az %>
-      server <%= "#{instance.address}:#{grafana.p('grafana.server.http_port')} fail_timeout=0;" %>
+      server <%= "#{instance.address}:#{p('nginx.grafana.upstream_port', grafana.p('grafana.server.http_port'))} fail_timeout=0;" %>
       <% end %>
     <% end %>
   }
@@ -172,7 +172,7 @@ http {
   upstream prometheus {
     <% prometheus.instances.map do |instance| %>
       <% if p('nginx.prometheus.cross_zone_load_balancing') || instance.az == spec.az %>
-      server <%= "#{instance.address}:#{prometheus.p('prometheus.web.port')} fail_timeout=0;" %>
+      server <%= "#{instance.address}:#{p('nginx.prometheus.upstream_port', prometheus.p('prometheus.web.port'))} fail_timeout=0;" %>
       <% end %>
     <% end %>
   }

--- a/jobs/nginx/templates/config/nginx.conf
+++ b/jobs/nginx/templates/config/nginx.conf
@@ -81,7 +81,7 @@ http {
     ssl off;
 
     <% if p('nginx.ssl_only') %>
-    return 301 https://$host$request_uri;
+    return 301 <%= p('nginx.alertmanager.https_redirect_url') %>;
     <% else %>
     include /var/vcap/jobs/nginx/config/alertmanager_location.conf;
     <% end %>
@@ -133,7 +133,7 @@ http {
     ssl off;
 
     <% if p('nginx.ssl_only') %>
-    return 301 https://$host$request_uri;
+    return 301 <%= p('nginx.grafana.https_redirect_url') %>;
     <% else %>
     include /var/vcap/jobs/nginx/config/grafana_location.conf;
     <% end %>
@@ -185,7 +185,7 @@ http {
     ssl off;
 
     <% if p('nginx.ssl_only') %>
-    return 301 https://$host$request_uri;
+    return 301 <%= p('nginx.prometheus.https_redirect_url') %>;
     <% else %>
     include /var/vcap/jobs/nginx/config/prometheus_location.conf;
     <% end %>

--- a/jobs/nginx/templates/config/nginx.conf
+++ b/jobs/nginx/templates/config/nginx.conf
@@ -68,7 +68,7 @@ http {
   upstream alertmanager {
     <% alertmanager.instances.map do |instance| %>
       <% if p('nginx.alertmanager.cross_zone_load_balancing') || instance.az == spec.az %>
-      server <%= "#{instance.address}:#{p('nginx.alertmanager.upstream_port', alertmanager.p('alertmanager.web.port'))} fail_timeout=0;" %>
+      server <%= "#{instance.address}:#{alertmanager.p('alertmanager.web.port')} fail_timeout=0;" %>
       <% end %>
     <% end %>
   }
@@ -120,7 +120,7 @@ http {
   upstream grafana {
     <% grafana.instances.map do |instance| %>
       <% if p('nginx.grafana.cross_zone_load_balancing') || instance.az == spec.az %>
-      server <%= "#{instance.address}:#{p('nginx.grafana.upstream_port', grafana.p('grafana.server.http_port'))} fail_timeout=0;" %>
+      server <%= "#{instance.address}:#{grafana.p('grafana.server.http_port')} fail_timeout=0;" %>
       <% end %>
     <% end %>
   }
@@ -172,7 +172,7 @@ http {
   upstream prometheus {
     <% prometheus.instances.map do |instance| %>
       <% if p('nginx.prometheus.cross_zone_load_balancing') || instance.az == spec.az %>
-      server <%= "#{instance.address}:#{p('nginx.prometheus.upstream_port', prometheus.p('prometheus.web.port'))} fail_timeout=0;" %>
+      server <%= "#{instance.address}:#{prometheus.p('prometheus.web.port')} fail_timeout=0;" %>
       <% end %>
     <% end %>
   }

--- a/jobs/prometheus2/spec
+++ b/jobs/prometheus2/spec
@@ -42,6 +42,8 @@ properties:
     description: "How frequently to evaluate rules by default"
   prometheus.external_labels:
     description: "Attach these labels to any time series or alerts when communicating with external systems"
+  prometheus.query_log_file:
+    description: "File to which PromQL queries are logged"
   prometheus.rule_files:
     description: "Array of paths to Prometheus rule files"
   prometheus.custom_rules:
@@ -50,6 +52,8 @@ properties:
     description: "Array of scrape configurations"
   prometheus.alert_relabel_configs:
     description: "Alerting relabel configuration"
+  prometheus.alertmanagers:
+    description: "Alertmanagers"
   prometheus.remote_write:
     description: "Remote write storage configuration"
   prometheus.remote_read:
@@ -76,6 +80,9 @@ properties:
   prometheus.rules.alert.resend_delay:
     description: "Minimum amount of time to wait before resending an alert to Alertmanager"
 
+  prometheus.storage.tsdb.allow_overlapping_blocks:
+    description: "Allow overlapping blocks, which in turn enables vertical compaction and vertical query merge"
+    default: false
   prometheus.storage.tsdb.retention.time:
     description: "How long to retain samples in the storage"
   prometheus.storage.tsdb.retention.size:

--- a/jobs/prometheus2/spec
+++ b/jobs/prometheus2/spec
@@ -122,6 +122,8 @@ properties:
     default: false
   prometheus.web.external_url:
     description: "The URL under which Prometheus is externally reachable"
+  prometheus.web.listen_address:
+    description: "Address to listen on for the web interface, API, and telemetry"
   prometheus.web.port:
     description: "Port to listen on for the web interface, API, and telemetry"
     default: "9090"

--- a/jobs/prometheus2/templates/bin/prometheus_ctl
+++ b/jobs/prometheus2/templates/bin/prometheus_ctl
@@ -123,7 +123,7 @@ case $1 in
       <% if_p('prometheus.web.external_url') do |external_url| %> \
       --web.external-url="<%= external_url %>" \
       <% end %> \
-      --web.listen-address=":<%= p('prometheus.web.port') %>" \
+      --web.listen-address="<%= p('prometheus.web.listen_address', '') %>:<%= p('prometheus.web.port') %>" \
       <% if_p('prometheus.web.max_connections') do |max_connections| %> \
       --web.max-connections="<%= max_connections %>" \
       <% end %> \

--- a/jobs/prometheus2/templates/bin/prometheus_ctl
+++ b/jobs/prometheus2/templates/bin/prometheus_ctl
@@ -72,6 +72,9 @@ case $1 in
       --rules.alert.resend-delay="<%= resend_delayt %>" \
       <% end %> \
       --storage.tsdb.path="${STORE_DIR}" \
+      <% if p('prometheus.storage.tsdb.allow_overlapping_blocks') %> \
+      --storage.tsdb.allow-overlapping-blocks \
+      <% end %> \
       <% if_p('prometheus.storage.tsdb.retention.time') do |retention| %> \
       --storage.tsdb.retention.time="<%= retention %>" \
       <% end %> \

--- a/jobs/prometheus2/templates/config/prometheus.yml
+++ b/jobs/prometheus2/templates/config/prometheus.yml
@@ -18,6 +18,11 @@ global:
   # external systems (federation, remote storage, Alertmanager).
   external_labels: <%= p('prometheus.external_labels', {}).to_json %>
 
+  <% if_p('prometheus.query_log_file') do |query_log_file| %>
+  # File to which PromQL queries are logged.
+  query_log_file: <%= query_log_file %>
+  <% end %>
+
 # Rule files specifies a list of files from which rules are read.
 rule_files: <%= p('prometheus.rule_files', []).push('/var/vcap/jobs/prometheus2/config/custom.rules.yml').to_json %>
 
@@ -35,16 +40,18 @@ scrape_configs: <%= scrape_configs.to_json %>
 # Alerting specifies settings related to the Alertmanager.
 alerting:
   alert_relabel_configs: <%= p('prometheus.alert_relabel_configs', []).to_json %>
-  <% if_link('alertmanager') do |alertmanager| %>
-  alertmanagers:
-    - static_configs:
-      - targets: <%= alertmanager.instances.map { |instance| "#{instance.address}:#{alertmanager.p('alertmanager.web.port')}" } %>
-      <% alertmanager.if_p('alertmanager.web.route_prefix') do |route_prefix| %>
-      path_prefix: <%= route_prefix %>
-      <% end %>
-  <% end %>
+  <% alertmanagers = p('prometheus.alertmanagers', []) %>
+  <% if_link('alertmanager') do |alertmanager|
+    alertmanagers.push({
+      'static_configs' => [{
+        'targets' => alertmanager.instances.map { |instance| "#{instance.address}:#{alertmanager.p('alertmanager.web.port')}" },
+      }],
+      'path_prefix' => alertmanager.p('alertmanager.web.route_prefix', '/'),
+    })
+  end %>
+  alertmanagers: <%= alertmanagers.to_json %>
 
-# Settings related to the experimental remote read feature.
+# Settings related to the remote read feature.
 <% if_link('prometheus-remote-read') do |prometheus_remote_read| %>
 remote_read:
   - url: http://<%= prometheus_remote_read.instances.first.address %>:<%= prometheus_remote_read.p('prometheus.web.port') %>/api/v1/read
@@ -52,7 +59,7 @@ remote_read:
 remote_read: <%= p('prometheus.remote_read', []).to_json %>
 <% end %>
 
-# Settings related to the experimental remote write feature.
+# Settings related to the remote write feature.
 <% if_link('prometheus-remote-write') do |prometheus_remote_write| %>
 remote_write:
   <% prometheus_remote_write.instances.each do |instance| %>


### PR DESCRIPTION
This PR brings some features that should be helpful for the infrastructure where a fronting proxy (e.g., oauth2-proxy) is deployed together with prometheus, grafana, and alertmanager VMs and have nginx access them. Furthermore, it adds missing features that are currently unsupported by this BOSH release. The bug fixes are included as well.

## New features
- `prometheus.web.listen_address`, `alertmanager.web.listen_address`
  - The port that Prometheus/Alertmanager listens to. It could be set to `127.0.0.1` so it limits access but from localhost.
  - Grafana already has this option.
- `nginx.prometheus.https_redirect_url`, `nginx.grafana.https_redirect_url`, and `nginx.alertmanager.https_redirect_url`
  - The redirect URL that nginx returns when redirecting to HTTPS, which is helpful to normalize address like `https://$server_name:$request_uri`.
- `prometheus.alertmanagers`
  - The current implementation does not support adding Alertmanager instances based on the service discovery of Prometheus. This PR allows it while retaining the current behavior.