### PR TITLE
Bump Statusmap to v4.2.0

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -63,9 +63,9 @@ grafana/grafana-7.5.11.linux-amd64.tar.gz:
   object_id: 996ee9e3-f46f-408a-4760-dcb026d4f8cb
   sha: sha256:f6c5d1688bac8e76c84df7d22f2d858f4babb77137563d01f040b2f25b1ee0c2
 grafana_plugins/flant-statusmap-panel-v0.3.4.zip:
-  size: 1313699
+  size: 286169
   object_id: 647b8279-789c-42fa-5369-6f8c8d6dfb9f
-  sha: sha256:9d57eebaa6590237e91c494902a29dbeb08cea2823e4ba609b05c3081d752839
+  sha: sha256:c1673d40021d2f4a857a19cc7c8933f9d509cb4fb7ffc095a7242dc157baf819
 grafana_plugins/grafana-clock-panel-v1.1.1.zip:
   size: 621739
   object_id: 9536cd55-c7d9-4f68-56a8-ab4b3f966eba

--- a/packages/grafana_plugins/packaging
+++ b/packages/grafana_plugins/packaging
@@ -3,7 +3,7 @@
 set -eux
 
 # Unzip Grafana Statusmap Panel
-unzip ${BOSH_COMPILE_TARGET}/grafana_plugins/flant-statusmap-panel-v0.3.4.zip -d ${BOSH_INSTALL_TARGET}
+unzip ${BOSH_COMPILE_TARGET}/grafana_plugins/flant-statusmap-panel-v0.4.2.zip -d ${BOSH_INSTALL_TARGET}
 
 # Unzip Clock Panel
 unzip ${BOSH_COMPILE_TARGET}/grafana_plugins/grafana-clock-panel-v1.1.1.zip -d ${BOSH_INSTALL_TARGET}

--- a/packages/grafana_plugins/spec
+++ b/packages/grafana_plugins/spec
@@ -3,7 +3,7 @@ name: grafana_plugins
 
 files:
   # https://grafana.com/api/plugins/<panel-name>/versions/<panel-version>/download
-  - grafana_plugins/flant-statusmap-panel-v0.3.4.zip
+  - grafana_plugins/flant-statusmap-panel-v0.4.2.zip
   - grafana_plugins/grafana-clock-panel-v1.1.1.zip
   - grafana_plugins/grafana-piechart-panel-v1.6.1.zip
   - grafana_plugins/grafana-worldmap-panel-v0.3.2.zip


### PR DESCRIPTION
This MR bumps the Grafana plugin `flant-statusmap-panel` from v0.3.4 to v0.4.2.

As per the [Statusmap-panel ChangeLog](https://github.com/flant/grafana-statusmap/blob/master/CHANGELOG.md), the version 0.3 does not work on Grafana 7.5+.

## Blobs

```bash
# fetch new release
wget -O flant-statusmap-panel-v0.4.2.zip https://grafana.com/api/plugins/flant-statusmap-panel/versions/0.4.2/download
# add tarball to blobs
bosh add-blob flant-statusmap-panel-v0.4.2.zip grafana_plugins/flant-statusmap-panel-v0.4.2.zip
# remove old blob
bosh remove-blob grafana_plugins/flant-statusmap-panel-v0.3.4.zip
```