### PR TITLE
Stop firing an alert for completed job pods

### DIFF
--- a/jobs/kubernetes_alerts/templates/pods.alerts.yml
+++ b/jobs/kubernetes_alerts/templates/pods.alerts.yml
@@ -2,7 +2,7 @@ groups:
   - name: pods
     rules:
       - alert: KubernetesPodNotRunning
-        expr: kube_pod_status_phase{phase!="Running"} == 1
+        expr: kube_pod_status_phase{phase!~"(Running|Completed)"} == 1
         for: <%= p('kubernetes_alerts.pod_not_running.evaluation_time') %>
         labels:
           service: kubernetes


### PR DESCRIPTION
We've noted that Kubernetes jobs that create pods, which then successfully run to completion, result in this alert firing.

e.g.

```
NAMESPACE               NAME                                        READY   STATUS      RESTARTS   AGE
kube-system             helm-install-traefik-zzzz                   0/1     Completed   0          18h
kube-system             traefik-xxxx-yyyy                           1/1     Running     0          18h
```

This PR treats a pod with status `Completed` as happy.