### PR TITLE
bump credhub_exporter to v0.10.1

### DIFF
--- a/packages/credhub_exporter/packaging
+++ b/packages/credhub_exporter/packaging
@@ -3,4 +3,4 @@
 set -eux
 
 mkdir -p ${BOSH_INSTALL_TARGET}/bin
-tar zxf credhub_exporter/credhub_exporter_0.5.1_linux_amd64.tar.gz --strip 1 -C ${BOSH_INSTALL_TARGET}/bin
+tar zxf credhub_exporter/credhub_exporter_0.10.1_linux_amd64.tar.gz --strip 1 -C ${BOSH_INSTALL_TARGET}/bin

--- a/packages/credhub_exporter/spec
+++ b/packages/credhub_exporter/spec
@@ -2,6 +2,6 @@
 name: credhub_exporter
 
 files:
-  - credhub_exporter/credhub_exporter_0.5.1_linux_amd64.tar.gz
+  - credhub_exporter/credhub_exporter_0.10.1_linux_amd64.tar.gz
 
 


### PR DESCRIPTION
### changelog

This PR bumps credhub_exporter to [v0.10.1](https://github.com/orange-cloudfoundry/credhub_exporter/releases/tag/v0.10.1)

### blobs
```
# fetch credhub exporter new release
wget https://github.com/orange-cloudfoundry/credhub_exporter/releases/download/v0.10.1/credhub_exporter_0.10.1_linux_amd64.tar.gz

# add tarball to blobs
bosh add-blob credhub_exporter_0.10.1_linux_amd64.tar.gz credhub_exporter/credhub_exporter_0.10.1_linux_amd64.tar.gz

# remove old blob
bosh remove-blob credhub_exporter/credhub_exporter_0.5.1_linux_amd64.tar.gz
```