### PR TITLE
Do not check credential aging for certificates

### DIFF
--- a/jobs/credhub_alerts/templates/credhub.alerts.yml
+++ b/jobs/credhub_alerts/templates/credhub.alerts.yml
@@ -1,8 +1,8 @@
 groups:
   - name: credhub
     rules:
-      - alert: CredhubCrendentialAging
-        expr: (time() - credhub_credential_created_at) / 86400 > <%= p('credhub_alerts.credential_expire.threshold') %>
+      - alert: CredhubCredentialAging
+        expr: (time() - credhub_credential_created_at{type!="certificate"}) / 86400 > <%= p('credhub_alerts.credential_expire.threshold') %>
         for: <%= p('credhub_alerts.credential_expire.evaluation_time') %>
         labels:
           severity: warning


### PR DESCRIPTION
The credential aging alert triggers on certificates but this is not so useful since certificates have their own expiration.
Also the CredHubCertificateWillExpire alert already notifies when certificates are about to expire.