### PR TITLE
Add grafana.auth.generic_oauth.{login,name}_attribute_path

### DIFF
--- a/jobs/grafana/spec
+++ b/jobs/grafana/spec
@@ -426,6 +426,10 @@ properties:
     description: "Generic OAuth email attribute name"
   grafana.auth.generic_oauth.email_attribute_path:
     description: "Generic OAuth email attribute path"
+  grafana.auth.generic_oauth.login_attribute_path:
+    description: "Generic OAuth login attribute path"
+  grafana.auth.generic_oauth.name_attribute_path:
+    description: "Generic OAuth name attribute path"
   grafana.auth.generic_oauth.role_attribute_path:
     description: "Generic OAuth role attribute path"
   grafana.auth.generic_oauth.auth_url:

--- a/jobs/grafana/templates/config/grafana.ini
+++ b/jobs/grafana/templates/config/grafana.ini
@@ -828,6 +828,14 @@ email_attribute_name = <%= email_attribute_name %>
 email_attribute_path = <%= email_attribute_path %>
 <% end %>
 
+<% if_p('grafana.auth.generic_oauth.login_attribute_path') do |login_attribute_path| %>
+login_attribute_path = <%= login_attribute_path %>
+<% end %>
+
+<% if_p('grafana.auth.generic_oauth.name_attribute_path') do |name_attribute_path| %>
+name_attribute_path = <%= name_attribute_path %>
+<% end %>
+
 <% if_p('grafana.auth.generic_oauth.role_attribute_path') do |role_attribute_path| %>
 role_attribute_path = <%= role_attribute_path %>
 <% end %>


### PR DESCRIPTION
Grafana job has missing properties configurable since Grafana 7.2+ so this PR adds them.
https://grafana.com/docs/grafana/v7.5/auth/generic-oauth/