### PR TITLE
Add alertmanager.time_intervals

### DIFF
--- a/jobs/alertmanager/spec
+++ b/jobs/alertmanager/spec
@@ -151,6 +151,8 @@ properties:
 
   alertmanager.mute_time_intervals:
     description: "Mute time intervals for muting routes."
+  alertmanager.time_intervals:
+    description: "Time intervals for muting/activating routes."
 
   alertmanager.test_alert.hourly:
     description: "Send a test alert hourly?"

--- a/jobs/alertmanager/templates/config/alertmanager.yml
+++ b/jobs/alertmanager/templates/config/alertmanager.yml
@@ -132,3 +132,8 @@ inhibit_rules: <%= inhibit_rules.to_json %>
 # A list of mute time intervals
 mute_time_intervals: <%= mute_time_intervals.to_json %>
 <% end %>
+
+<% if_p('alertmanager.time_intervals') do |time_intervals| %>
+# A list of time intervals
+time_intervals: <%= time_intervals.to_json %>
+<% end %>


### PR DESCRIPTION
Alertmanager added time_intervals to manage muting/activating routes and deprecated the previously added mute_intervals. This PR adds `time_intervals` while leaving `mute_time_intervals` as is.

Compare:
* https://prometheus.io/docs/alerting/0.23/configuration/
* https://prometheus.io/docs/alerting/0.24/configuration/