### PR TITLE
fix cadvisor packaging script

### DIFF
--- a/packages/cadvisor/packaging
+++ b/packages/cadvisor/packaging
@@ -9,4 +9,5 @@ cp -a ${BOSH_COMPILE_TARGET}/common/* ${BOSH_INSTALL_TARGET}/common
 # Extract cadvisor package
 mkdir -p ${BOSH_INSTALL_TARGET}/bin
 tar xzvf ${BOSH_COMPILE_TARGET}/cadvisor/cadvisor-0.46.0.tar.gz -C ${BOSH_INSTALL_TARGET}/bin
+mv ${BOSH_INSTALL_TARGET}/bin/cadvisor-v0.46.0-linux-amd64 ${BOSH_INSTALL_TARGET}/bin/cadvisor
 chmod +x ${BOSH_INSTALL_TARGET}/bin/cadvisor


### PR DESCRIPTION
The prometheus bosh-release cannot be compiled since [v27.2.0](https://github.com/bosh-prometheus/prometheus-boshrelease/releases/tag/v27.2.0)

The problem comes from the `cadvistor` package which produces the following compilation error:
```
ask 81260 | 07:56:22 | Compiling packages: cadvisor/77c88de37951a032f07ec208184f47b1349388ce73a16e18c4e9f743384170b0 (00:02:12)
                      L Error: Action Failed get_task: Task 8e7a8cf4-aef9-4b51-7026-ffe6e3a964d8 result: Compiling package cadvisor: Running packaging script: Running packaging script: Command exited with 1; Stdout: , Stderr: + mkdir -p /var/vcap/packages/cadvisor/common
+ cp -a /var/vcap/data/compile/cadvisor/common/utils.sh /var/vcap/packages/cadvisor/common
+ mkdir -p /var/vcap/packages/cadvisor/bin
+ tar xzvf /var/vcap/data/compile/cadvisor/cadvisor/cadvisor-0.46.0.tar.gz -C /var/vcap/packages/cadvisor/bin
+ chmod +x /var/vcap/packages/cadvisor/bin/cadvisor
chmod: cannot access '/var/vcap/packages/cadvisor/bin/cadvisor': No such file or directory

Task 81260 | 07:58:34 | Error: Action Failed get_task: Task 8e7a8cf4-aef9-4b51-7026-ffe6e3a964d8 result: Compiling package cadvisor: Running packaging script: Running packaging script: Command exited with 1; Stdout: , Stderr: + mkdir -p /var/vcap/packages/cadvisor/common
+ cp -a /var/vcap/data/compile/cadvisor/common/utils.sh /var/vcap/packages/cadvisor/common
+ mkdir -p /var/vcap/packages/cadvisor/bin
+ tar xzvf /var/vcap/data/compile/cadvisor/cadvisor/cadvisor-0.46.0.tar.gz -C /var/vcap/packages/cadvisor/bin
+ chmod +x /var/vcap/packages/cadvisor/bin/cadvisor
chmod: cannot access '/var/vcap/packages/cadvisor/bin/cadvisor': No such file or directory
```

My guess is that the new blob `cadvisor-0.46.0.tar.gz` has a different tarball layout than the previous `cadvisor/cadvisor-0.37.0.tar.gz`. The upstream repository [google/cadvisor](https://github.com/google/cadvisor) also have this layout change is its release assets file names: [v0.46.0](https://github.com/google/cadvisor/releases/tag/v0.46.0) vs [v0.37.0](https://github.com/google/cadvisor/releases/tag/v0.37.0).