### PR TITLE
Grafana: id_token_attribute_name configuration in generic oauth

### DIFF
--- a/jobs/grafana/spec
+++ b/jobs/grafana/spec
@@ -432,6 +432,8 @@ properties:
     description: "Generic OAuth name attribute path"
   grafana.auth.generic_oauth.role_attribute_path:
     description: "Generic OAuth role attribute path"
+  grafana.auth.generic_oauth.id_token_attribute_name:
+    description: "Attribute name to read token from token authorization response"
   grafana.auth.generic_oauth.auth_url:
     description: "Generic OAuth url"
   grafana.auth.generic_oauth.token_url:

--- a/jobs/grafana/templates/config/grafana.ini
+++ b/jobs/grafana/templates/config/grafana.ini
@@ -840,6 +840,10 @@ name_attribute_path = <%= name_attribute_path %>
 role_attribute_path = <%= role_attribute_path %>
 <% end %>
 
+<% if_p('grafana.auth.generic_oauth.id_token_attribute_name') do |id_token_attribute_name| %>
+id_token_attribute_name = <%= id_token_attribute_name %>
+<% end %>
+
 <% if_p('grafana.auth.generic_oauth.auth_url') do |auth_url| %>
 auth_url = <%= auth_url %>
 <% end %>


### PR DESCRIPTION
This PR adds the `grafana.auth.generic_oauth.id_token_attribute_name` spec property.

This property allows to configure `[auth.generic_oauth] / id_token_attribute_name` described in [grafana's documentation](https://grafana.com/docs/grafana/v8.5/auth/generic-oauth/#login).

Configuring this property can be useful to read login information from `access_token` instead of default `id_token`.
