### PR TITLE
nginx is aware of hosts file changes

### DIFF
--- a/jobs/nginx/monit
+++ b/jobs/nginx/monit
@@ -3,3 +3,6 @@ check process nginx
   start program "/var/vcap/jobs/nginx/bin/nginx_ctl start"
   stop program "/var/vcap/jobs/nginx/bin/nginx_ctl stop"
   group vcap
+
+check file hosts with path /etc/hosts
+  if changed timestamp then exec "/usr/bin/bash -c '/usr/bin/kill -s SIGHUP $(cat /var/vcap/sys/run/nginx/nginx.pid)'"


### PR DESCRIPTION
## Why

Looking at [this issue](https://github.com/bosh-prometheus/prometheus-boshrelease/issues/452), I feel the solution can be fairly easy. `monit` can track file changes and can have `nginx` process react to these changes. Sending a `SIGHUP` signal to the parent `nginx` process is enough for the workers to refresh.

## How to test

run `touch /etc/hosts` and see that nginx workers get replaced:
```
# ps fax | grep nginx
  47130 ?        S<     0:00 nginx: master process nginx -p /var/vcap/sys/tmp/nginx -c /var/vcap/jobs/nginx/config/nginx.conf
  47441 ?        S<     0:00  \_ nginx: worker process
  47442 ?        S<     0:00  \_ nginx: worker process
....
# ps fax | grep nginx
  47130 ?        S<     0:00 nginx: master process nginx -p /var/vcap/sys/tmp/nginx -c /var/vcap/jobs/nginx/config/nginx.conf
  47556 ?        S<     0:00  \_ nginx: worker process
  47557 ?        S<     0:00  \_ nginx: worker process
```