### PR TITLE
Add property to enable the prometheus built-in remote write receiver

### DIFF
--- a/jobs/prometheus2/spec
+++ b/jobs/prometheus2/spec
@@ -123,6 +123,9 @@ properties:
   prometheus.web.enable_admin_api:
     description: "Enables API endpoints for admin control actions"
     default: false
+  prometheus.web.enable_remote_write_receiver:
+    description: "Enables the built-in remote write receiver"
+    default: false
   prometheus.web.external_url:
     description: "The URL under which Prometheus is externally reachable"
   prometheus.web.listen_address:

--- a/jobs/prometheus2/templates/bin/prometheus_ctl
+++ b/jobs/prometheus2/templates/bin/prometheus_ctl
@@ -120,6 +120,9 @@ case $1 in
       <% if p('prometheus.web.enable_admin_api') %> \
       --web.enable-admin-api \
       <% end %> \
+      <% if p('prometheus.web.enable_remote_write_receiver') %> \
+      --web.enable-remote-write-receiver \
+      <% end %> \
       <% if_p('prometheus.web.external_url') do |external_url| %> \
       --web.external-url="<%= external_url %>" \
       <% end %> \


### PR DESCRIPTION
I think the prometheus remote write receiver can currently be enabled using a feature flag, but it's flag is deprecated so thought it might be worth adding support for `--web.enable-remote-write-receiver` - https://prometheus.io/docs/prometheus/latest/feature_flags/#remote-write-receiver
