### PR TITLE
[alertmanager] Add config to disable clustering

### DIFF
--- a/jobs/alertmanager/spec
+++ b/jobs/alertmanager/spec
@@ -42,6 +42,9 @@ properties:
     description: "Time to wait between peers to send notifications"
   alertmanager.mesh.port:
     description: "Deprecated. Please use alertmanager.cluster.port"
+  alertmanager.cluster.enabled:
+    description: "Enable clustering of alertmanager for production use"
+    default: true
   alertmanager.cluster.port:
     description: "Cluster listen port"
     default: 9094

--- a/jobs/alertmanager/templates/bin/alertmanager_ctl
+++ b/jobs/alertmanager/templates/bin/alertmanager_ctl
@@ -48,39 +48,43 @@ case $1 in
       <% if_p('alertmanager.log_format') do |log_format| %> \
       --log.format="<%= log_format %>" \
       <% end %> \
+      <% if p('alertmanager.cluster.enabled', true) == false %> \
+      --cluster.listen-address= \
+      <% else %> \
       --cluster.listen-address=<%= "#{p('alertmanager.cluster.listen_address', spec.ip)}:#{p('alertmanager.mesh.port', p('alertmanager.cluster.port'))}" %> \
-      <% if_p('alertmanager.cluster.advertise_address') do |address| %> \
+        <% if_p('alertmanager.cluster.advertise_address') do |address| %> \
       --cluster.advertise-address="<%= "#{address}:#{p('alertmanager.mesh.port', p('alertmanager.cluster.port'))}" %>" \
-      <% end %> \
-      <% if_p('alertmanager.cluster.gossip_interval') do |gossip_interval| %> \
+        <% end %> \
+        <% if_p('alertmanager.cluster.gossip_interval') do |gossip_interval| %> \
       --cluster.gossip-interval="<%= gossip_interval %>" \
-      <% end %> \
-      <% link('alertmanager').instances.each do |instance|  %> \
+        <% end %> \
+        <% link('alertmanager').instances.each do |instance|  %> \
       --cluster.peer="<%= "#{instance.address}:#{link('alertmanager').p('alertmanager.mesh.port', p('alertmanager.cluster.port'))}" %>" \
-      <% end %> \
-      <% if_p('alertmanager.cluster.peer_timeout') do |peer_timeout| %> \
+        <% end %> \
+        <% if_p('alertmanager.cluster.peer_timeout') do |peer_timeout| %> \
       --cluster.peer-timeout="<%= peer_timeout %>" \
-      <% end %> \
-      <% if_p('alertmanager.cluster.probe_interval') do |probe_interval| %> \
+        <% end %> \
+        <% if_p('alertmanager.cluster.probe_interval') do |probe_interval| %> \
       --cluster.probe-interval="<%= probe_interval %>" \
-      <% end %> \
-      <% if_p('alertmanager.cluster.probe_timeout') do |probe_timeout| %> \
+        <% end %> \
+        <% if_p('alertmanager.cluster.probe_timeout') do |probe_timeout| %> \
       --cluster.probe-timeout="<%= probe_timeout %>" \
-      <% end %> \
-      <% if_p('alertmanager.cluster.pushpull_interval') do |pushpull_interval| %> \
+        <% end %> \
+        <% if_p('alertmanager.cluster.pushpull_interval') do |pushpull_interval| %> \
       --cluster.pushpull-interval="<%= pushpull_interval %>" \
-      <% end %> \
-      <% if_p('alertmanager.cluster.reconnect_interval') do |reconnect_interval| %> \
+        <% end %> \
+        <% if_p('alertmanager.cluster.reconnect_interval') do |reconnect_interval| %> \
       --cluster.reconnect-interval="<%= reconnect_interval %>" \
-      <% end %> \
-      <% if_p('alertmanager.cluster.reconnect_timeout') do |reconnect_timeout| %> \
+        <% end %> \
+        <% if_p('alertmanager.cluster.reconnect_timeout') do |reconnect_timeout| %> \
       --cluster.reconnect-timeout="<%= reconnect_timeout %>" \
-      <% end %> \
-      <% if_p('alertmanager.cluster.settle_timeout') do |settle_timeout| %> \
+        <% end %> \
+        <% if_p('alertmanager.cluster.settle_timeout') do |settle_timeout| %> \
       --cluster.settle-timeout="<%= settle_timeout %>" \
-      <% end %> \
-      <% if_p('alertmanager.cluster.tcp_timeout') do |tcp_timeout| %> \
+        <% end %> \
+        <% if_p('alertmanager.cluster.tcp_timeout') do |tcp_timeout| %> \
       --cluster.tcp-timeout="<%= tcp_timeout %>" \
+        <% end %> \
       <% end %> \
       --storage.path="${STORE_DIR}" \
       <% if_p('alertmanager.web.external_url') do |external_url| %> \

--- a/jobs/alertmanager/templates/bin/alertmanager_ctl
+++ b/jobs/alertmanager/templates/bin/alertmanager_ctl
@@ -49,7 +49,7 @@ case $1 in
       --log.format="<%= log_format %>" \
       <% end %> \
       <% if p('alertmanager.cluster.enabled', true) == false %> \
-      --cluster.listen-address= \
+      --cluster.listen-address="" \
       <% else %> \
       --cluster.listen-address=<%= "#{p('alertmanager.cluster.listen_address', spec.ip)}:#{p('alertmanager.mesh.port', p('alertmanager.cluster.port'))}" %> \
         <% if_p('alertmanager.cluster.advertise_address') do |address| %> \

--- a/manifests/operators/alertmanager-disable-clustering.yml
+++ b/manifests/operators/alertmanager-disable-clustering.yml
@@ -1,0 +1,3 @@
+- type: replace
+  path: /instance_groups/name=alertmanager/jobs/name=alertmanager/properties/alertmanager/cluster?/enabled
+  value: false


### PR DESCRIPTION
When only one alertmanager instance is deployed, alertmanager_cluster_messages_queued will rise over time until it hits 4k queue limit resulting in dropping alerts (https://github.com/prometheus/alertmanager/issues/1814). This PR enables operators to disable clustering for alertmanager.