### PR TITLE
bump cf_exporter from v1.0.0 to v1.0.1

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -18,10 +18,10 @@ cadvisor/cadvisor-v0.46.0-linux-amd64:
   size: 29
   object_id: 036b5e7f-22a0-47f9-7935-bb49a6f34a34
   sha: sha256:3cd8cda66399b60836a3e08ad0ec596a8650e4ff584736e0631e653229804e95
-cf_exporter/cf_exporter_1.0.0.linux-amd64.tar.gz:
-  size: 6880501
-  object_id: c191fb50-f3aa-43fe-7514-c66f663fbdc5
-  sha: sha256:303ac729668b9822f80da81e36ab5f83f53fa9a4c2a6e54075341649504082b9
+cf_exporter/cf_exporter_1.0.1.linux-amd64.tar.gz:
+  size: 6987930
+  object_id: ad87a513-3fc3-46d3-6cf5-b1554a2e500d
+  sha: sha256:7b402ef142c6ab48ea526174986aba32b409d25022708b7a39f88bb82047e935
 collectd_exporter/collectd_exporter-0.5.0.linux-amd64.tar.gz:
   size: 7253249
   object_id: 6584fd01-47ea-4cd2-75de-cf191caaa33f

--- a/packages/cf_exporter/packaging
+++ b/packages/cf_exporter/packaging
@@ -3,4 +3,4 @@
 set -eux
 
 mkdir -p ${BOSH_INSTALL_TARGET}/bin
-tar zxf cf_exporter/cf_exporter_1.0.0.linux-amd64.tar.gz --strip 1 -C ${BOSH_INSTALL_TARGET}/bin
+tar zxf cf_exporter/cf_exporter_1.0.1.linux-amd64.tar.gz --strip 1 -C ${BOSH_INSTALL_TARGET}/bin

--- a/packages/cf_exporter/spec
+++ b/packages/cf_exporter/spec
@@ -2,4 +2,4 @@
 name: cf_exporter
 
 files:
-  - cf_exporter/cf_exporter_1.0.0.linux-amd64.tar.gz
+  - cf_exporter/cf_exporter_1.0.1.linux-amd64.tar.gz


### PR DESCRIPTION
This PR bump [cf_exporter](https://github.com/bosh-prometheus/cf_exporter/) from `v1.0.0` to [v1.0.1](https://github.com/bosh-prometheus/cf_exporter/releases/tag/v1.0.1), which includes:
- concurrent requests are handled correctly
  - (bosh-prometheus/cf_exporter#82)
- connexions to api are correctly closed 
  - (bosh-prometheus/cf_exporter#81)

*Note*: new blob has been uploaded