### PR TITLE
bump cf_exporter to v1.1.0

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -18,10 +18,10 @@ cadvisor/cadvisor-v0.47.0-linux-amd64:
   size: 44642706
   object_id: 92e9dea2-22f4-4284-510a-a5697dc25328
   sha: sha256:caf4491298e0702f9d0c6a1d1949767f5c6400f77e12cd3524d6d3fcc66abc2a
-cf_exporter/cf_exporter_1.0.1.linux-amd64.tar.gz:
-  size: 6987930
-  object_id: ad87a513-3fc3-46d3-6cf5-b1554a2e500d
-  sha: sha256:7b402ef142c6ab48ea526174986aba32b409d25022708b7a39f88bb82047e935
+cf_exporter/cf_exporter_1.1.0.linux-amd64.tar.gz:
+  size: 6988459
+  object_id: 53b851b8-6ab8-46b2-7356-2b26e6a846bd
+  sha: sha256:bfc66e44c92eae21271fb466c37df77a5f2bff32508f2af0f169c6192d66dceb
 collectd_exporter/collectd_exporter-0.5.0.linux-amd64.tar.gz:
   size: 7253249
   object_id: 6584fd01-47ea-4cd2-75de-cf191caaa33f

--- a/packages/cf_exporter/packaging
+++ b/packages/cf_exporter/packaging
@@ -3,4 +3,4 @@
 set -eux
 
 mkdir -p ${BOSH_INSTALL_TARGET}/bin
-tar zxf cf_exporter/cf_exporter_1.0.1.linux-amd64.tar.gz --strip 1 -C ${BOSH_INSTALL_TARGET}/bin
+tar zxf cf_exporter/cf_exporter_1.1.0.linux-amd64.tar.gz --strip 1 -C ${BOSH_INSTALL_TARGET}/bin

--- a/packages/cf_exporter/spec
+++ b/packages/cf_exporter/spec
@@ -2,4 +2,4 @@
 name: cf_exporter
 
 files:
-  - cf_exporter/cf_exporter_1.0.1.linux-amd64.tar.gz
+  - cf_exporter/cf_exporter_1.1.0.linux-amd64.tar.gz


### PR DESCRIPTION
bump cf_exporter to [v1.1.0](https://github.com/bosh-prometheus/cf_exporter/releases/tag/v1.1.0), fixes bosh-prometheus/cf_exporter#85