### PR TITLE
fix grafana store folder permissions

### DIFF
--- a/jobs/grafana/templates/bin/pre-start
+++ b/jobs/grafana/templates/bin/pre-start
@@ -6,6 +6,9 @@ set -eu
 mkdir -p /usr/share/fonts/freefont
 cp -a /var/vcap/packages/grafana/freefont/* /usr/share/fonts/freefont
 
+# grafana is ran with bpm as user vcap
+chown vcap:vcap -R /var/vcap/store/grafana
+
 echo "[$(date)] Calling 'prometheus-dashboards' ..."
 $(dirname $0)/prometheus-dashboards
 


### PR DESCRIPTION
This PR fixes a permission problem introduced by #468 

Managing grafana service from bpm will run the process with user `vcap`  instead of user `root`. Pre-existing data need a permission update prior to grafana startup. 