### PR TITLE
Make sure /var/vcap/store/grafana exists

### DIFF
--- a/jobs/grafana/templates/bin/pre-start
+++ b/jobs/grafana/templates/bin/pre-start
@@ -7,6 +7,7 @@ mkdir -p /usr/share/fonts/freefont
 cp -a /var/vcap/packages/grafana/freefont/* /usr/share/fonts/freefont
 
 # grafana is ran with bpm as user vcap
+mkdir -p /var/vcap/store/grafana
 chown vcap:vcap -R /var/vcap/store/grafana
 
 echo "[$(date)] Calling 'prometheus-dashboards' ..."


### PR DESCRIPTION
`pre-start` script runs `chown` against `/var/vcap/store/grafana` which does not exist on new deployments with persistent `/var/vcap/store` mount point.

This small fix makes sure that `/var/vcap/store/grafana` gets created beforehand.