### PR TITLE
Grafana SQLite3 supports WAL

### DIFF
--- a/jobs/grafana/spec
+++ b/jobs/grafana/spec
@@ -140,6 +140,8 @@ properties:
     description: "(MySQL only) The common name field of the certificate used by the mysql server. Not necessary if ssl_mode is set to 'skip-verify'"
   grafana.database.log_queries:
     description: "Set to true to log the sql calls and execution times"
+  grafana.database.wal:
+    description: "(SQLite3 only & optional) Setting it to true enables SQLite WAL (Write-Ahead Logging). Possible values are true, false. If not set defaults to false for Grafana"
 
   grafana.remote_cache.type:
     description: "Either 'redis', 'memcached', 'database'"

--- a/jobs/grafana/templates/config/grafana.ini
+++ b/jobs/grafana/templates/config/grafana.ini
@@ -162,6 +162,10 @@ path = /var/vcap/store/grafana/grafana.db
 # For "sqlite3" only. cache mode setting used for connecting to the database
 cache_mode = <%= cache_mode %>
 <% end %>
+<% if_p('grafana.database.wal') do |wal| %>
+# Enable/disable Write-Ahead Logging, https://sqlite.org/wal.html. WAL has benefits when sqlite3 struggles with locks.
+wal = <%= wal %>
+<% end %>
 <% elsif p('grafana.database.type') == "mysql" || p('grafana.database.type') == "postgres" %>
 <%
   database_host = nil


### PR DESCRIPTION
In recent deployments we found out that Grafana SQLite3 is locking with an error "Database locked, sleeping then retrying". 

Following [an issue raised](https://github.com/grafana/grafana/issues/65115) in Grafana we are introducing a solution we found useful. Seems that enabling WAL (Write-Ahead Logging, https://sqlite.org/wal.html) in `grafana.ini` resolves the problem.

Using this new Grafana spec property called `grafana.database.wal` enables this feature.