### PR TITLE
add retro_compat.disable property

### DIFF
--- a/jobs/firehose_exporter/spec
+++ b/jobs/firehose_exporter/spec
@@ -56,6 +56,9 @@ properties:
   firehose_exporter.filter.events:
     description: "Comma separated events to filter (ContainerMetric, CounterEvent, Http, ValueMetric)"
     default: ""
+  firehose_exporter.retro_compat.disable:
+    description: "Disable retro compatibility"
+    default: false
 
   # web server configuration
   firehose_exporter.web.port:

--- a/jobs/firehose_exporter/templates/bpm.yml.erb
+++ b/jobs/firehose_exporter/templates/bpm.yml.erb
@@ -25,6 +25,7 @@ env = {
   "FIREHOSE_EXPORTER_WEB_LISTEN_ADDRESS"       => ":#{p('firehose_exporter.web.port')}",
   "FIREHOSE_EXPORTER_WEB_TELEMETRY_PATH"       => p('firehose_exporter.web.telemetry_path'),
   "FIREHOSE_EXPORTER_LOG_LEVEL"                => p('firehose_exporter.log_level'),
+  "FIREHOSE_EXPORTER_RETRO_COMPAT_DISABLE"     => p('firehose_exporter.retro_compat.disable'),
 }
 
 # when value are true


### PR DESCRIPTION
This PR add the possibility to disable the retrocompatibilty on the firehose exporter.
https://github.com/bosh-prometheus/prometheus-boshrelease/issues/483