### PR TITLE
bump cf_exporter to v1.2.2

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -8,7 +8,7 @@
 | [collectd_exporter]       |                  | v0.5.0  | ![][collectd_exporter-ver]       | ![][collectd_exporter-act]       |
 | [consul_exporter]         |                  | v0.9.0  | ![][consul_exporter-ver]         | ![][consul_exporter-act]         |
 | [credhub_exporter]        | bosh             | v0.28.0 | ![][credhub_exporter-ver]        | ![][credhub_exporter-act]        |
-| [cf_exporter]             | cf               | v1.2.1  | ![][cf_exporter-ver]             | ![][cf_exporter-act]             |
+| [cf_exporter]             | cf               | v1.2.2  | ![][cf_exporter-ver]             | ![][cf_exporter-act]             |
 | [firehose_exporter]       | cf               | v7.1.1  | ![][firehose_exporter-ver]       | ![][firehose_exporter-act]       |
 | [flant/statusmap-panel]   | grafana_plugings | v0.5.1  | ![][flant/statusmap-panel-ver]   | ![][flant/statusmap-panel-act]   |
 | [fontconfig]              | grafana          | v2.14.2 |                                  |                                  |

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -18,10 +18,10 @@ cadvisor/cadvisor-v0.47.0-linux-amd64:
   size: 44642706
   object_id: 92e9dea2-22f4-4284-510a-a5697dc25328
   sha: sha256:caf4491298e0702f9d0c6a1d1949767f5c6400f77e12cd3524d6d3fcc66abc2a
-cf_exporter/cf_exporter_1.2.1.linux-amd64.tar.gz:
-  size: 6935627
-  object_id: b482ff28-a49b-442f-5c82-130bd405110a
-  sha: sha256:ec3ef0eb41922a9ef89bd4f1533e043ab288e5d25da26ff8cce78b9b5f1adb26
+cf_exporter/cf_exporter_1.2.2.linux-amd64.tar.gz:
+  size: 6937602
+  object_id: 9195882e-4b9b-410a-5f41-97bb6ebe7d91
+  sha: sha256:491d00bef9e544970f8472587d4fc328b4d4b1c8e56e7a100319d40c2cc74ba2
 collectd_exporter/collectd_exporter-0.5.0.linux-amd64.tar.gz:
   size: 7253249
   object_id: 6584fd01-47ea-4cd2-75de-cf191caaa33f

--- a/packages/cf_exporter/packaging
+++ b/packages/cf_exporter/packaging
@@ -3,4 +3,4 @@
 set -eux
 
 mkdir -p ${BOSH_INSTALL_TARGET}/bin
-tar zxf cf_exporter/cf_exporter_1.2.1.linux-amd64.tar.gz --strip 1 -C ${BOSH_INSTALL_TARGET}/bin
+tar zxf cf_exporter/cf_exporter_1.2.2.linux-amd64.tar.gz --strip 1 -C ${BOSH_INSTALL_TARGET}/bin

--- a/packages/cf_exporter/spec
+++ b/packages/cf_exporter/spec
@@ -2,4 +2,4 @@
 name: cf_exporter
 
 files:
-  - cf_exporter/cf_exporter_1.2.1.linux-amd64.tar.gz
+  - cf_exporter/cf_exporter_1.2.2.linux-amd64.tar.gz


### PR DESCRIPTION
bump cf_exporter to v1.2.2
* this version of cf_exporter fixes wrongly renamed label `application_id`