### PR TITLE
add retro_compat.enable_delta option

### DIFF
--- a/jobs/firehose_exporter/spec
+++ b/jobs/firehose_exporter/spec
@@ -59,6 +59,10 @@ properties:
   firehose_exporter.retro_compat.disable:
     description: "Disable retro compatibility"
     default: false
+  firehose_exporter.retro_compat.enable_delta:
+    description: "Enable retro compatibility delta in counter"
+    default: false
+
 
   # web server configuration
   firehose_exporter.web.port:

--- a/jobs/firehose_exporter/templates/bpm.yml.erb
+++ b/jobs/firehose_exporter/templates/bpm.yml.erb
@@ -26,6 +26,7 @@ env = {
   "FIREHOSE_EXPORTER_WEB_TELEMETRY_PATH"       => p('firehose_exporter.web.telemetry_path'),
   "FIREHOSE_EXPORTER_LOG_LEVEL"                => p('firehose_exporter.log_level'),
   "FIREHOSE_EXPORTER_RETRO_COMPAT_DISABLE"     => p('firehose_exporter.retro_compat.disable'),
+  "FIREHOSE_EXPORTER_RETRO_COMPAT_ENABLE_DELTA"     => p('firehose_exporter.retro_compat.enable_delta'),
 }
 
 # when value are true


### PR DESCRIPTION
As describe here : https://github.com/bosh-prometheus/firehose_exporter/blob/master/FAQ.md
the Delta is not exported by default, enable it by using retro_compat.enable_delta command flag.
This PR add the possibility to enable this option.