### PR TITLE
Add insecure email lookup property to Grafana

### DIFF
--- a/jobs/grafana/spec
+++ b/jobs/grafana/spec
@@ -347,6 +347,8 @@ properties:
     description: "mask the Grafana version number for unauthenticated users"
   grafana.auth.oauth_skip_org_role_update_sync:
     description: "Skip forced assignment of OrgID 1 or 'auto_assign_org_id' for social logins"
+  grafana.auth.oauth_allow_insecure_email_lookup:
+    description: "Enable user lookup based on email in addition to using unique ID provided by IdPs."
   grafana.auth.azure_auth_enabled:
     description: "Set to true to enable Azure authentication option for HTTP-based datasources"
 

--- a/jobs/grafana/templates/config/grafana.ini
+++ b/jobs/grafana/templates/config/grafana.ini
@@ -720,6 +720,11 @@ oauth_state_cookie_max_age = <%= oauth_state_cookie_max_age %>
 oauth_skip_org_role_update_sync = <%= oauth_skip_org_role_update_sync %>
 <% end %>
 
+<% if_p('grafana.auth.oauth_allow_insecure_email_lookup') do |oauth_allow_insecure_email_lookup| %>
+# Enable user lookup based on email in addition to using unique ID provided by IdPs.
+oauth_allow_insecure_email_lookup = <%= oauth_allow_insecure_email_lookup %>
+<% end %>
+
 <% if_p('grafana.auth.api_key_max_seconds_to_live') do |api_key_max_seconds_to_live| %>
 # limit of api_key seconds to live before expiration
 api_key_max_seconds_to_live = <%= api_key_max_seconds_to_live %>


### PR DESCRIPTION
Adds a possibility to enable insecure email lookup for Grafana (https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/#enable-email-lookup) disabled by default for Grafana v10+.