### PR TITLE
Adds possibility to customize --collector.workers argument's value in cf_exporter job configuration

### DIFF
--- a/jobs/cf_exporter/spec
+++ b/jobs/cf_exporter/spec
@@ -22,6 +22,9 @@ properties:
     description: "Cloud Foundry Client Secret"
   cf_exporter.cf.deployment_name:
     description: "Cloud Foundry Deployment Name to be reported as a metric label"
+  cf_exporter.collector.workers:
+    description: "Number of workers to use for collectors"
+    default: 10
   cf_exporter.filter.collectors:
     description: "Comma separated collectors to filter (Applications,Buildpacks,Events,IsolationSegments,Organizations,Routes,SecurityGroups,ServiceBindings,ServiceInstances,ServicePlans,Services,Spaces,Stacks), If not set, all collectors except Events are enabled."
   cf_exporter.log_stream:

--- a/jobs/cf_exporter/templates/bpm.yml.erb
+++ b/jobs/cf_exporter/templates/bpm.yml.erb
@@ -5,6 +5,7 @@ args = [
   "--log.level",  p("cf_exporter.log_level"),
   "--log.stream", p("cf_exporter.log_stream"),
   "--cf.api_url", p("cf_exporter.cf.api_url"),
+  "--collector.workers", p("cf_exporter.collector.workers"),
 ]
 
 # program env variables


### PR DESCRIPTION
`cf_exporter` binary allow usage of `--collector.workers` arguments to customize number of workers that'll be used to fetch informations from cf api.
