### PR TITLE
Bump Routing release forward by about 4 years

### DIFF
--- a/manifests/operators/enable-cf-route-registrar.yml
+++ b/manifests/operators/enable-cf-route-registrar.yml
@@ -57,7 +57,7 @@
 - type: replace
   path: /releases/-
   value:
-    name: routing
-    version: 0.317.0
-    url: https://d3r5lzz0qww9ge.cloudfront.net/routing-0.317.0.tgz
-    sha1: sha256:92d4172b1883f85738b03694184a686119fd25b99486e1853a407d53cdf45e87
+    name: "routing"
+    version: "0.321.0"
+    url: "https://bosh.io/d/github.com/cloudfoundry/routing-release?v=0.321.0"
+    sha1: "3a0714e5df14d03f62d29ae24071e5667330f49a"


### PR DESCRIPTION
Replace routing-release from 2020 with one from 2024.

I am debugging the routing on one of our clients and noticed the release is very old. Therefore I would like to update this ops to use a recent version of Routing release. 