### PR TITLE
Adjust manifests to use Prometheus3 instead of Prometheus2

### DIFF
--- a/manifests/operators/configure-bosh-exporter-uaa-client-id.yml
+++ b/manifests/operators/configure-bosh-exporter-uaa-client-id.yml
@@ -2,5 +2,5 @@
 
 # Configure a custom bosh_exporter UAA client_id
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=bosh_exporter/properties/bosh_exporter/bosh/uaa/client_id
+  path: /instance_groups/name=prometheus/jobs/name=bosh_exporter/properties/bosh_exporter/bosh/uaa/client_id
   value: ((uaa_bosh_exporter_client_id))

--- a/manifests/operators/deprecated/monitor-cf-attic.yml
+++ b/manifests/operators/deprecated/monitor-cf-attic.yml
@@ -31,9 +31,9 @@
 
 # replace cloudfoundry_alerts job by cloudfoundry_alerts-attic
 - type: remove
-  path: /instance_groups/name=prometheus2/jobs/name=cloudfoundry_alerts
+  path: /instance_groups/name=prometheus/jobs/name=cloudfoundry_alerts
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/-
+  path: /instance_groups/name=prometheus/jobs/-
   value:
     name: cloudfoundry_alerts-attic
     release: prometheus
@@ -49,7 +49,7 @@
 
 # add attic assets to prometheus and grafana
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/rule_files/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/rule_files/-
   value: /var/vcap/jobs/cloudfoundry_alerts-attic/*.alerts.yml
 - type: replace
   path: /instance_groups/name=grafana/jobs/name=grafana/properties/grafana/prometheus/dashboard_folders/name=Cloudfoundry?/files/-

--- a/manifests/operators/dev/test-alerts.yml
+++ b/manifests/operators/dev/test-alerts.yml
@@ -1,161 +1,161 @@
 # Bosh alerts
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=bosh_alerts?/release
+  path: /instance_groups/name=prometheus/jobs/name=bosh_alerts?/release
   value: prometheus
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/rule_files/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/rule_files/-
   value: /var/vcap/jobs/bosh_alerts/*.alerts.yml
 
 # Cloud Foundry alerts
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=cloudfoundry_alerts?/release
+  path: /instance_groups/name=prometheus/jobs/name=cloudfoundry_alerts?/release
   value: prometheus
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/rule_files/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/rule_files/-
   value: /var/vcap/jobs/cloudfoundry_alerts/*.alerts.yml
 
 # Concourse alerts
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=concourse_alerts?/release
+  path: /instance_groups/name=prometheus/jobs/name=concourse_alerts?/release
   value: prometheus
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/rule_files/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/rule_files/-
   value: /var/vcap/jobs/concourse_alerts/*.alerts.yml
 
 # Consul alerts
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=consul_alerts?/release
+  path: /instance_groups/name=prometheus/jobs/name=consul_alerts?/release
   value: prometheus
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/rule_files/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/rule_files/-
   value: /var/vcap/jobs/consul_alerts/*.alerts.yml
 
 # Credhub alerts
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=crehub_alerts?/release
+  path: /instance_groups/name=prometheus/jobs/name=crehub_alerts?/release
   value: prometheus
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/rule_files/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/rule_files/-
   value: /var/vcap/jobs/credhub_alerts/*.alerts.yml
 
 # Elasticsearch alerts
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=elasticsearch_alerts?/release
+  path: /instance_groups/name=prometheus/jobs/name=elasticsearch_alerts?/release
   value: prometheus
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/rule_files/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/rule_files/-
   value: /var/vcap/jobs/elasticsearch_alerts/*.alerts.yml
 
 # HAProxy alerts
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=haproxy_alerts?/release
+  path: /instance_groups/name=prometheus/jobs/name=haproxy_alerts?/release
   value: prometheus
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/rule_files/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/rule_files/-
   value: /var/vcap/jobs/haproxy_alerts/*.alerts.yml
 
 # Kubernetes alerts
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=kubernetes_alerts?/release
+  path: /instance_groups/name=prometheus/jobs/name=kubernetes_alerts?/release
   value: prometheus
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/rule_files/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/rule_files/-
   value: /var/vcap/jobs/kubernetes_alerts/*.alerts.yml
 
 # MySQL alerts
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=mysql_alerts?/release
+  path: /instance_groups/name=prometheus/jobs/name=mysql_alerts?/release
   value: prometheus
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/rule_files/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/rule_files/-
   value: /var/vcap/jobs/mysql_alerts/*.alerts.yml
 
 # RabbitMQ for PCF alerts
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=p_rabbitmq_alerts?/release
+  path: /instance_groups/name=prometheus/jobs/name=p_rabbitmq_alerts?/release
   value: prometheus
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/rule_files/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/rule_files/-
   value: /var/vcap/jobs/p_rabbitmq_alerts/*.alerts.yml
 
 # Redis for PCF alerts
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=p_redis_alerts?/release
+  path: /instance_groups/name=prometheus/jobs/name=p_redis_alerts?/release
   value: prometheus
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/rule_files/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/rule_files/-
   value: /var/vcap/jobs/p_redis_alerts/*.alerts.yml
 
 # PostgreSQL alerts
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=postgres_alerts/release
+  path: /instance_groups/name=prometheus/jobs/name=postgres_alerts/release
   value: prometheus
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/rule_files/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/rule_files/-
   value: /var/vcap/jobs/postgres_alerts/*.alerts.yml
 
 # Probe alerts
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=probe_alerts?/release
+  path: /instance_groups/name=prometheus/jobs/name=probe_alerts?/release
   value: prometheus
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/rule_files/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/rule_files/-
   value: /var/vcap/jobs/probe_alerts/*.alerts.yml
 
 # Prometheus alerts
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus_alerts?/release
+  path: /instance_groups/name=prometheus/jobs/name=prometheus_alerts?/release
   value: prometheus
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/rule_files/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/rule_files/-
   value: /var/vcap/jobs/prometheus_alerts/*.alerts.yml
 
 # RabbitMQ alerts
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=rabbitmq_alerts?/release
+  path: /instance_groups/name=prometheus/jobs/name=rabbitmq_alerts?/release
   value: prometheus
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/rule_files/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/rule_files/-
   value: /var/vcap/jobs/rabbitmq_alerts/*.alerts.yml
 
 # Redis Alerts
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=redis_alerts?/release
+  path: /instance_groups/name=prometheus/jobs/name=redis_alerts?/release
   value: prometheus
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/rule_files/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/rule_files/-
   value: /var/vcap/jobs/redis_alerts/*.alerts.yml
 
 # Shield alerts
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=shield_alerts?/release
+  path: /instance_groups/name=prometheus/jobs/name=shield_alerts?/release
   value: prometheus
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/rule_files/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/rule_files/-
   value: /var/vcap/jobs/shield_alerts/*.alerts.yml
 
   # Vault alerts
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=vault_alerts?/release
+  path: /instance_groups/name=prometheus/jobs/name=vault_alerts?/release
   value: prometheus
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/rule_files/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/rule_files/-
   value: /var/vcap/jobs/vault_alerts/*.alerts.yml

--- a/manifests/operators/enable-bosh-uaa.yml
+++ b/manifests/operators/enable-bosh-uaa.yml
@@ -2,7 +2,7 @@
 
 # Use bosh_exporter UAA client
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=bosh_exporter/properties/bosh_exporter/bosh
+  path: /instance_groups/name=prometheus/jobs/name=bosh_exporter/properties/bosh_exporter/bosh
   value:
     url: "((bosh_url))"
     uaa:

--- a/manifests/operators/enable-cf-route-registrar.yml
+++ b/manifests/operators/enable-cf-route-registrar.yml
@@ -5,7 +5,7 @@
 
 # Prometheus URL
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/web?/external_url
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/web?/external_url
   value: https://prometheus.((system_domain))
 
 # Grafana URL

--- a/manifests/operators/enable-service-discovery.yml
+++ b/manifests/operators/enable-service-discovery.yml
@@ -1,5 +1,5 @@
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/-
+  path: /instance_groups/name=prometheus/jobs/-
   value:
     name: service_discovery
     release: prometheus

--- a/manifests/operators/monitor-bosh-director.yml
+++ b/manifests/operators/monitor-bosh-director.yml
@@ -1,5 +1,5 @@
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties?/prometheus/scrape_configs/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties?/prometheus/scrape_configs/-
   value:
     job_name: bosh_director_metrics
     metrics_path: /metrics
@@ -11,14 +11,14 @@
       - ((bosh_ip)):9091
     tls_config:
       ca_contents: ((bosh_metrics_server_client.ca))
-      ca_file: /var/vcap/jobs/prometheus2/certs/bosh_metrics_ca.cert
+      ca_file: /var/vcap/jobs/prometheus/certs/bosh_metrics_ca.cert
       cert_contents: ((bosh_metrics_server_client.certificate))
-      cert_file: /var/vcap/jobs/prometheus2/certs/bosh_metrics_cert.cert
+      cert_file: /var/vcap/jobs/prometheus/certs/bosh_metrics_cert.cert
       key_contents: ((bosh_metrics_server_client.private_key))
-      key_file: /var/vcap/jobs/prometheus2/certs/bosh_metrics_key.cert
+      key_file: /var/vcap/jobs/prometheus/certs/bosh_metrics_key.cert
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties?/prometheus/scrape_configs/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties?/prometheus/scrape_configs/-
   value:
     job_name: bosh_director_api_metrics
     metrics_path: /api_metrics
@@ -30,8 +30,8 @@
       - ((bosh_ip)):9091
     tls_config:
       ca_contents: ((bosh_metrics_server_client.ca))
-      ca_file: /var/vcap/jobs/prometheus2/certs/bosh_metrics_ca.cert
+      ca_file: /var/vcap/jobs/prometheus/certs/bosh_metrics_ca.cert
       cert_contents: ((bosh_metrics_server_client.certificate))
-      cert_file: /var/vcap/jobs/prometheus2/certs/bosh_metrics_cert.cert
+      cert_file: /var/vcap/jobs/prometheus/certs/bosh_metrics_cert.cert
       key_contents: ((bosh_metrics_server_client.private_key))
-      key_file: /var/vcap/jobs/prometheus2/certs/bosh_metrics_key.cert
+      key_file: /var/vcap/jobs/prometheus/certs/bosh_metrics_key.cert

--- a/manifests/operators/monitor-bosh.yml
+++ b/manifests/operators/monitor-bosh.yml
@@ -1,6 +1,6 @@
 # Exporter jobs
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/-
+  path: /instance_groups/name=prometheus/jobs/-
   value:
     name: bosh_exporter
     release: prometheus
@@ -16,11 +16,11 @@
 
 # Prometheus Alerts
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=bosh_alerts?/release
+  path: /instance_groups/name=prometheus/jobs/name=bosh_alerts?/release
   value: prometheus
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/rule_files/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/rule_files/-
   value: /var/vcap/jobs/bosh_alerts/*.alerts.yml
 
 # Grafana Dashboards
@@ -38,7 +38,7 @@
 
 # Prometheus Scrape Config
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/scrape_configs/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/scrape_configs/-
   value:
     job_name: bosh
     scrape_interval: 2m
@@ -49,7 +49,7 @@
 
 # Service Discovery
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/scrape_configs/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/scrape_configs/-
   value:
     job_name: bosh_tsdb
     file_sd_configs:
@@ -67,7 +67,7 @@
         replacement: "${1}:9194"
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/scrape_configs/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/scrape_configs/-
   value:
     job_name: cadvisor
     file_sd_configs:
@@ -85,7 +85,7 @@
         replacement: "${1}:8080"
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/scrape_configs/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/scrape_configs/-
   value:
     job_name: cf
     scrape_interval: 4m
@@ -105,7 +105,7 @@
         replacement: "${1}:9193"
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/scrape_configs/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/scrape_configs/-
   value:
     job_name: collectd
     file_sd_configs:
@@ -123,7 +123,7 @@
         replacement: "${1}:9103"
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/scrape_configs/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/scrape_configs/-
   value:
     job_name: consul
     file_sd_configs:
@@ -141,7 +141,7 @@
         replacement: "${1}:9107"
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/scrape_configs/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/scrape_configs/-
   value:
     job_name: credhub
     scrape_interval: 4m
@@ -161,7 +161,7 @@
         replacement: "${1}:9358"
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/scrape_configs/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/scrape_configs/-
   value:
     job_name: elasticsearch
     file_sd_configs:
@@ -179,7 +179,7 @@
         replacement: "${1}:9114"
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/scrape_configs/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/scrape_configs/-
   value:
     job_name: ingestor_exporter
     file_sd_configs:
@@ -197,7 +197,7 @@
         replacement: "${1}:9495"
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/scrape_configs/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/scrape_configs/-
   value:
     job_name: concourse
     file_sd_configs:
@@ -219,7 +219,7 @@
         replacement: "${1}:9391"
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/scrape_configs/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/scrape_configs/-
   value:
     job_name: firehose
     file_sd_configs:
@@ -237,7 +237,7 @@
         replacement: "${1}:9186"
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/scrape_configs/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/scrape_configs/-
   value:
     job_name: grafana
     file_sd_configs:
@@ -255,7 +255,7 @@
         replacement: "${1}:3000"
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/scrape_configs/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/scrape_configs/-
   value:
     job_name: graphite
     file_sd_configs:
@@ -273,7 +273,7 @@
         replacement: "${1}:9108"
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/scrape_configs/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/scrape_configs/-
   value:
     job_name: haproxy
     file_sd_configs:
@@ -282,16 +282,16 @@
     relabel_configs:
       - source_labels:
         - __meta_bosh_job_process_name
-        regex: haproxy_stats
+        regex: haproxy_exporter
         action: keep
       - source_labels:
         - __address__
         regex: "(.*)"
         target_label: __address__
-        replacement: "${1}:9000"
+        replacement: "${1}:9101"
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/scrape_configs/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/scrape_configs/-
   value:
     job_name: influxdb
     file_sd_configs:
@@ -309,7 +309,7 @@
         replacement: "${1}:9122"
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/scrape_configs/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/scrape_configs/-
   value:
     job_name: kubernetes
     file_sd_configs:
@@ -327,7 +327,7 @@
         replacement: "${1}:9188"
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/scrape_configs/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/scrape_configs/-
   value:
     job_name: memcached
     file_sd_configs:
@@ -345,7 +345,7 @@
         replacement: "${1}:9150"
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/scrape_configs/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/scrape_configs/-
   value:
     job_name: mongodb
     file_sd_configs:
@@ -363,7 +363,7 @@
         replacement: "${1}:9001"
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/scrape_configs/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/scrape_configs/-
   value:
     job_name: mysql
     file_sd_configs:
@@ -381,7 +381,7 @@
         replacement: "${1}:9104"
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/scrape_configs/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/scrape_configs/-
   value:
     job_name: nats
     file_sd_configs:
@@ -399,7 +399,7 @@
         replacement: "${1}:9118"
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/scrape_configs/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/scrape_configs/-
   value:
     job_name: node
     file_sd_configs:
@@ -417,7 +417,7 @@
         replacement: "${1}:9100"
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/scrape_configs/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/scrape_configs/-
   value:
     job_name: postgres
     file_sd_configs:
@@ -435,7 +435,7 @@
         replacement: "${1}:9187"
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/scrape_configs/job_name=prometheus
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/scrape_configs/job_name=prometheus
   value:
     job_name: prometheus
     file_sd_configs:
@@ -453,7 +453,7 @@
         replacement: "${1}:9090"
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/scrape_configs/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/scrape_configs/-
   value:
     job_name: pushgateway
     honor_labels: true
@@ -472,7 +472,7 @@
         replacement: "${1}:9091"
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/scrape_configs/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/scrape_configs/-
   value:
     job_name: rabbitmq
     file_sd_configs:
@@ -490,7 +490,7 @@
         replacement: "${1}:9125"
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/scrape_configs/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/scrape_configs/-
   value:
     job_name: redis
     file_sd_configs:
@@ -508,7 +508,7 @@
         replacement: "${1}:9121"
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/scrape_configs/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/scrape_configs/-
   value:
     job_name: shield
     scrape_interval: 4m
@@ -528,7 +528,7 @@
         replacement: "${1}:9179"
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/scrape_configs/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/scrape_configs/-
   value:
     job_name: stackdriver
     file_sd_configs:
@@ -546,7 +546,7 @@
         replacement: "${1}:9255"
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/scrape_configs/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/scrape_configs/-
   value:
     job_name: statsd
     file_sd_configs:
@@ -564,7 +564,7 @@
         replacement: "${1}:9102"
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/scrape_configs/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/scrape_configs/-
   value:
     job_name: vault
     file_sd_configs:

--- a/manifests/operators/monitor-cadvisor.yml
+++ b/manifests/operators/monitor-cadvisor.yml
@@ -2,7 +2,7 @@
 
 # Exporter jobs
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/-
+  path: /instance_groups/name=prometheus/jobs/-
   value:
     name: cadvisor
     release: prometheus

--- a/manifests/operators/monitor-cf.yml
+++ b/manifests/operators/monitor-cf.yml
@@ -3,7 +3,7 @@
 
 # Exporter jobs
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/-
+  path: /instance_groups/name=prometheus/jobs/-
   value:
     name: cf_exporter
     release: prometheus
@@ -19,7 +19,7 @@
         skip_ssl_verify: ((skip_ssl_verify))
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=bpm?
+  path: /instance_groups/name=prometheus/jobs/name=bpm?
   value:
     name: bpm
     release: bpm
@@ -75,11 +75,11 @@
 
 # Prometheus Alerts
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=cloudfoundry_alerts?/release
+  path: /instance_groups/name=prometheus/jobs/name=cloudfoundry_alerts?/release
   value: prometheus
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/rule_files/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/rule_files/-
   value: /var/vcap/jobs/cloudfoundry_alerts/*.alerts.yml
 
 # Grafana Dashboards

--- a/manifests/operators/monitor-collectd.yml
+++ b/manifests/operators/monitor-collectd.yml
@@ -2,7 +2,7 @@
 
 # Exporter jobs
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/-
+  path: /instance_groups/name=prometheus/jobs/-
   value:
     name: collectd_exporter
     release: prometheus

--- a/manifests/operators/monitor-concourse.yml
+++ b/manifests/operators/monitor-concourse.yml
@@ -2,11 +2,11 @@
 
 # Prometheus Alerts
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=concourse_alerts?/release
+  path: /instance_groups/name=prometheus/jobs/name=concourse_alerts?/release
   value: prometheus
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/rule_files/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/rule_files/-
   value: /var/vcap/jobs/concourse_alerts/*.alerts.yml
 
 # Grafana Dashboards

--- a/manifests/operators/monitor-consul.yml
+++ b/manifests/operators/monitor-consul.yml
@@ -2,7 +2,7 @@
 
 # Exporter jobs
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/-
+  path: /instance_groups/name=prometheus/jobs/-
   value:
     name: consul_exporter
     release: prometheus
@@ -12,11 +12,11 @@
 
 # Prometheus Alerts
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=consul_alerts?/release
+  path: /instance_groups/name=prometheus/jobs/name=consul_alerts?/release
   value: prometheus
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/rule_files/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/rule_files/-
   value: /var/vcap/jobs/consul_alerts/*.alerts.yml
 
 # Grafana Dashboards

--- a/manifests/operators/monitor-credhub.yml
+++ b/manifests/operators/monitor-credhub.yml
@@ -2,13 +2,13 @@
 
 # Exporter jobs
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=bpm?
+  path: /instance_groups/name=prometheus/jobs/name=bpm?
   value:
     name: bpm
     release: bpm
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/-
+  path: /instance_groups/name=prometheus/jobs/-
   value:
     name: credhub_exporter
     release: prometheus
@@ -29,11 +29,11 @@
 
 # Prometheus Alerts
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=credhub_alerts?/release
+  path: /instance_groups/name=prometheus/jobs/name=credhub_alerts?/release
   value: prometheus
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/rule_files/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/rule_files/-
   value: /var/vcap/jobs/credhub_alerts/*.alerts.yml
 
 # Grafana Dashboards

--- a/manifests/operators/monitor-elasticsearch.yml
+++ b/manifests/operators/monitor-elasticsearch.yml
@@ -4,7 +4,7 @@
 
 # Exporter jobs
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/-
+  path: /instance_groups/name=prometheus/jobs/-
   value:
     name: elasticsearch_exporter
     release: prometheus
@@ -15,11 +15,11 @@
 
 # Prometheus Alerts
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=elasticsearch_alerts?/release
+  path: /instance_groups/name=prometheus/jobs/name=elasticsearch_alerts?/release
   value: prometheus
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/rule_files/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/rule_files/-
   value: /var/vcap/jobs/elasticsearch_alerts/*.alerts.yml
 
 # Grafana Dashboards

--- a/manifests/operators/monitor-graphite.yml
+++ b/manifests/operators/monitor-graphite.yml
@@ -2,7 +2,7 @@
 
 # Exporter jobs
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/-
+  path: /instance_groups/name=prometheus/jobs/-
   value:
     name: graphite_exporter
     release: prometheus

--- a/manifests/operators/monitor-haproxy.yml
+++ b/manifests/operators/monitor-haproxy.yml
@@ -1,17 +1,24 @@
-# Scrape targets
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties?/prometheus/scrape_configs/-
+# This file assumes bosh_exporter based Service Discovery is being used: ./monitor-bosh.yml
+
+# Exporter jobs
+- type: replace
+  path: /instance_groups/name=prometheus/jobs/-
   value:
-    job_name: haproxy_stats
-    static_configs:
-    - targets: ((haproxy_scrape_uri)))
+    name: haproxy_exporter
+    release: prometheus
+    properties:
+      haproxy_exporter:
+        haproxy:
+          pid_file: "((haproxy_pid_file))"
+          scrape_uri: "((haproxy_scrape_uri))"
 
 # Prometheus Alerts
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=haproxy_alerts?/release
+  path: /instance_groups/name=prometheus/jobs/name=haproxy_alerts?/release
   value: prometheus
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/rule_files/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/rule_files/-
   value: /var/vcap/jobs/haproxy_alerts/*.alerts.yml
 
 # Grafana Dashboards

--- a/manifests/operators/monitor-http-probe.yml
+++ b/manifests/operators/monitor-http-probe.yml
@@ -2,7 +2,7 @@
 
 # Exporter jobs
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/-
+  path: /instance_groups/name=prometheus/jobs/-
   value:
     name: blackbox_exporter
     release: prometheus
@@ -19,7 +19,7 @@
 
 # Prometheus Scrape Config
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/scrape_configs/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/scrape_configs/-
   value:
     job_name: blackbox
     metrics_path: /probe
@@ -44,11 +44,11 @@
 
 # Prometheus Alerts
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=probe_alerts?/release
+  path: /instance_groups/name=prometheus/jobs/name=probe_alerts?/release
   value: prometheus
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/rule_files/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/rule_files/-
   value: /var/vcap/jobs/probe_alerts/*.alerts.yml
 
 # Grafana Dashboards

--- a/manifests/operators/monitor-influxdb.yml
+++ b/manifests/operators/monitor-influxdb.yml
@@ -2,7 +2,7 @@
 
 # Exporter jobs
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/-
+  path: /instance_groups/name=prometheus/jobs/-
   value:
     name: influxdb_exporter
     release: prometheus

--- a/manifests/operators/monitor-kubernetes.yml
+++ b/manifests/operators/monitor-kubernetes.yml
@@ -2,7 +2,7 @@
 
 # Exporter jobs
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/-
+  path: /instance_groups/name=prometheus/jobs/-
   value:
     name: kube_state_metrics_exporter
     release: prometheus
@@ -18,7 +18,7 @@
 # cluster, or can't connect to nodes for some other reason (e.g. because of
 # firewalling).
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/scrape_configs/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/scrape_configs/-
   value:
     job_name: kubernetes_nodes
     scheme: ((kubernetes_apiserver_scheme))
@@ -49,7 +49,7 @@
 # default named port `https`. This works for single API server deployments as
 # well as HA API server deployments.
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/scrape_configs/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/scrape_configs/-
   value:
     job_name: kubernetes_apiservers
     scheme: ((kubernetes_apiserver_scheme))
@@ -69,11 +69,11 @@
 
 # Prometheus Alerts
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=kubernetes_alerts?/release
+  path: /instance_groups/name=prometheus/jobs/name=kubernetes_alerts?/release
   value: prometheus
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/rule_files/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/rule_files/-
   value: /var/vcap/jobs/kubernetes_alerts/*.alerts.yml
 
 # Grafana Dashboards

--- a/manifests/operators/monitor-memcached.yml
+++ b/manifests/operators/monitor-memcached.yml
@@ -2,7 +2,7 @@
 
 # Exporter jobs
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/-
+  path: /instance_groups/name=prometheus/jobs/-
   value:
     name: memcached_exporter
     release: prometheus

--- a/manifests/operators/monitor-mongodb.yml
+++ b/manifests/operators/monitor-mongodb.yml
@@ -2,7 +2,7 @@
 
 # Exporter jobs
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/-
+  path: /instance_groups/name=prometheus/jobs/-
   value:
     name: mongodb_exporter
     release: prometheus

--- a/manifests/operators/monitor-mysql.yml
+++ b/manifests/operators/monitor-mysql.yml
@@ -2,7 +2,7 @@
 
 # Exporter jobs
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/-
+  path: /instance_groups/name=prometheus/jobs/-
   value:
     name: mysqld_exporter
     release: prometheus
@@ -15,11 +15,11 @@
 
 # Prometheus Alerts
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=mysql_alerts?/release
+  path: /instance_groups/name=prometheus/jobs/name=mysql_alerts?/release
   value: prometheus
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/rule_files/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/rule_files/-
   value: /var/vcap/jobs/mysql_alerts/*.alerts.yml
 
 # Grafana Dashboards

--- a/manifests/operators/monitor-nats.yml
+++ b/manifests/operators/monitor-nats.yml
@@ -2,7 +2,7 @@
 
 # Exporter jobs
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/-
+  path: /instance_groups/name=prometheus/jobs/-
   value:
     name: nats_exporter
     release: prometheus

--- a/manifests/operators/monitor-p-rabbitmq.yml
+++ b/manifests/operators/monitor-p-rabbitmq.yml
@@ -2,11 +2,11 @@
 
 # Prometheus Alerts
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=p_rabbitmq_alerts?/release
+  path: /instance_groups/name=prometheus/jobs/name=p_rabbitmq_alerts?/release
   value: prometheus
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/rule_files/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/rule_files/-
   value: /var/vcap/jobs/p_rabbitmq_alerts/*.alerts.yml
 
 # Grafana Dashboards

--- a/manifests/operators/monitor-p-redis.yml
+++ b/manifests/operators/monitor-p-redis.yml
@@ -2,11 +2,11 @@
 
 # Prometheus Alerts
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=p_redis_alerts?/release
+  path: /instance_groups/name=prometheus/jobs/name=p_redis_alerts?/release
   value: prometheus
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/rule_files/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/rule_files/-
   value: /var/vcap/jobs/p_redis_alerts/*.alerts.yml
 
 # Grafana Dashboards

--- a/manifests/operators/monitor-postgres.yml
+++ b/manifests/operators/monitor-postgres.yml
@@ -2,7 +2,7 @@
 
 # Exporter jobs
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/-
+  path: /instance_groups/name=prometheus/jobs/-
   value:
     name: postgres_exporter
     release: prometheus
@@ -12,11 +12,11 @@
 
 # Prometheus Alerts
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=postgres_alerts?/release
+  path: /instance_groups/name=prometheus/jobs/name=postgres_alerts?/release
   value: prometheus
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/rule_files/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/rule_files/-
   value: /var/vcap/jobs/postgres_alerts/*.alerts.yml
 
 # Grafana Dashboards

--- a/manifests/operators/monitor-pushgateway.yml
+++ b/manifests/operators/monitor-pushgateway.yml
@@ -2,7 +2,7 @@
 
 # Exporter jobs
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/-
+  path: /instance_groups/name=prometheus/jobs/-
   value:
     name: pushgateway
     release: prometheus

--- a/manifests/operators/monitor-rabbitmq.yml
+++ b/manifests/operators/monitor-rabbitmq.yml
@@ -2,7 +2,7 @@
 
 # Exporter jobs
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/-
+  path: /instance_groups/name=prometheus/jobs/-
   value:
     name: rabbitmq_exporter
     release: prometheus
@@ -15,11 +15,11 @@
 
 # Prometheus Alerts
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=rabbitmq_alerts?/release
+  path: /instance_groups/name=prometheus/jobs/name=rabbitmq_alerts?/release
   value: prometheus
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/rule_files/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/rule_files/-
   value: /var/vcap/jobs/rabbitmq_alerts/*.alerts.yml
 
 # Grafana Dashboards

--- a/manifests/operators/monitor-redis.yml
+++ b/manifests/operators/monitor-redis.yml
@@ -2,7 +2,7 @@
 
 # Exporter jobs
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/-
+  path: /instance_groups/name=prometheus/jobs/-
   value:
     name: redis_exporter
     release: prometheus
@@ -13,11 +13,11 @@
 
 # Prometheus Alerts
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=redis_alerts?/release
+  path: /instance_groups/name=prometheus/jobs/name=redis_alerts?/release
   value: prometheus
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/rule_files/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/rule_files/-
   value: /var/vcap/jobs/redis_alerts/*.alerts.yml
 
 # Grafana Dashboards

--- a/manifests/operators/monitor-shield.yml
+++ b/manifests/operators/monitor-shield.yml
@@ -2,7 +2,7 @@
 
 # Exporter jobs
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/-
+  path: /instance_groups/name=prometheus/jobs/-
   value:
     name: shield_exporter
     release: prometheus
@@ -18,11 +18,11 @@
 
 # Prometheus Alerts
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=shield_alerts?/release
+  path: /instance_groups/name=prometheus/jobs/name=shield_alerts?/release
   value: prometheus
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/rule_files/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/rule_files/-
   value: /var/vcap/jobs/shield_alerts/*.alerts.yml
 
 # Grafana Dashboards

--- a/manifests/operators/monitor-stackdriver.yml
+++ b/manifests/operators/monitor-stackdriver.yml
@@ -2,7 +2,7 @@
 
 # Exporter jobs
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/-
+  path: /instance_groups/name=prometheus/jobs/-
   value:
     name: stackdriver_exporter
     release: prometheus

--- a/manifests/operators/monitor-statsd.yml
+++ b/manifests/operators/monitor-statsd.yml
@@ -2,7 +2,7 @@
 
 # Exporter jobs
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/-
+  path: /instance_groups/name=prometheus/jobs/-
   value:
     name: statsd_exporter
     release: prometheus

--- a/manifests/operators/monitor-vault.yml
+++ b/manifests/operators/monitor-vault.yml
@@ -2,7 +2,7 @@
 
 # Exporter jobs
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/-
+  path: /instance_groups/name=prometheus/jobs/-
   value:
     name: vault_exporter
     release: prometheus
@@ -12,9 +12,9 @@
 
 # Prometheus Alerts
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=vault_alerts?/release
+  path: /instance_groups/name=prometheus/jobs/name=vault_alerts?/release
   value: prometheus
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/rule_files/-
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/rule_files/-
   value: /var/vcap/jobs/vault_alerts/*.alerts.yml

--- a/manifests/operators/prometheus-web-external-url.yml
+++ b/manifests/operators/prometheus-web-external-url.yml
@@ -1,5 +1,5 @@
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/web?/external_url?
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/web?/external_url?
   value: ((prometheus_web_external_url))
 
 - type: replace

--- a/manifests/operators/proxy/enable-proxy-blackbox-exporter.yml
+++ b/manifests/operators/proxy/enable-proxy-blackbox-exporter.yml
@@ -1,5 +1,5 @@
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=blackbox_exporter/properties?/env?
+  path: /instance_groups/name=prometheus/jobs/name=blackbox_exporter/properties?/env?
   value:
     http_proxy: ((http_proxy))
     https_proxy: ((https_proxy))

--- a/manifests/operators/proxy/enable-proxy-bosh-exporter.yml
+++ b/manifests/operators/proxy/enable-proxy-bosh-exporter.yml
@@ -1,5 +1,5 @@
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=bosh_exporter/properties?/env?
+  path: /instance_groups/name=prometheus/jobs/name=bosh_exporter/properties?/env?
   value:
     http_proxy: ((http_proxy))
     https_proxy: ((https_proxy))

--- a/manifests/operators/proxy/enable-proxy-cf-exporter.yml
+++ b/manifests/operators/proxy/enable-proxy-cf-exporter.yml
@@ -1,5 +1,5 @@
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=cf_exporter/properties?/env?
+  path: /instance_groups/name=prometheus/jobs/name=cf_exporter/properties?/env?
   value:
     http_proxy: ((http_proxy))
     https_proxy: ((https_proxy))

--- a/manifests/operators/proxy/enable-proxy-kubernetes.yml
+++ b/manifests/operators/proxy/enable-proxy-kubernetes.yml
@@ -1,14 +1,14 @@
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=kube_state_metrics_exporter/properties?/env?
+  path: /instance_groups/name=prometheus/jobs/name=kube_state_metrics_exporter/properties?/env?
   value:
     http_proxy: ((http_proxy))
     https_proxy: ((https_proxy))
     no_proxy: ((no_proxy))
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/scrape_configs/job_name=kubernetes_nodes/proxy_url?
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/scrape_configs/job_name=kubernetes_nodes/proxy_url?
   value: ((http_proxy))
 
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties/prometheus/scrape_configs/job_name=kubernetes_apiservers/proxy_url?
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties/prometheus/scrape_configs/job_name=kubernetes_apiservers/proxy_url?
   value: ((http_proxy))

--- a/manifests/operators/proxy/enable-proxy-prometheus.yml
+++ b/manifests/operators/proxy/enable-proxy-prometheus.yml
@@ -1,5 +1,5 @@
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=prometheus2/properties?/env?
+  path: /instance_groups/name=prometheus/jobs/name=prometheus/properties?/env?
   value:
     http_proxy: ((http_proxy))
     https_proxy: ((https_proxy))

--- a/manifests/operators/proxy/enable-proxy-shield-exporter.yml
+++ b/manifests/operators/proxy/enable-proxy-shield-exporter.yml
@@ -1,5 +1,5 @@
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=shield_exporter/properties?/env?
+  path: /instance_groups/name=prometheus/jobs/name=shield_exporter/properties?/env?
   value:
     http_proxy: ((http_proxy))
     https_proxy: ((https_proxy))

--- a/manifests/operators/proxy/enable-proxy-stackdriver-exporter.yml
+++ b/manifests/operators/proxy/enable-proxy-stackdriver-exporter.yml
@@ -1,5 +1,5 @@
 - type: replace
-  path: /instance_groups/name=prometheus2/jobs/name=stackdriver_exporter/properties?/env?
+  path: /instance_groups/name=prometheus/jobs/name=stackdriver_exporter/properties?/env?
   value:
     http_proxy: ((http_proxy))
     https_proxy: ((https_proxy))

--- a/manifests/prometheus.yml
+++ b/manifests/prometheus.yml
@@ -23,7 +23,9 @@ instance_groups:
             test_alert:
               daily: true
 
-  - name: prometheus2
+  - name: prometheus
+    migrated_from: 
+    - name: prometheus2
     azs:
       - z1
     instances: 1
@@ -33,7 +35,7 @@ instance_groups:
     networks:
       - name: default
     jobs:
-      - name: prometheus2
+      - name: prometheus
         release: prometheus
         properties:
           prometheus:


### PR DESCRIPTION
The Manifests have been adjusted to replace Prometheus2 with Prometheus and added a migrated_from for prometheus2 instance_groups to not lose data while updating.

Related to #504 