### PR TITLE
Update cf_cells_capacity dashboard

### DIFF
--- a/jobs/cloudfoundry_dashboards/templates/cf_cells_capacity.json
+++ b/jobs/cloudfoundry_dashboards/templates/cf_cells_capacity.json
@@ -984,6 +984,6 @@
   "timezone": "browser",
   "title": "CF: Cells Capacity",
   "uid": "cf_cells_capacity",
-  "version": 1,
+  "version": 5,
   "weekStart": ""
 }


### PR DESCRIPTION
Fixes angular warnings, and also removed bosh_deployment as has been done in other dashboards.

Part of https://github.com/cloudfoundry/prometheus-boshrelease/issues/508