### PR TITLE
Changes for Prometheus3 - BBS config for cf_exporter and custom.rules.yml

### DIFF
--- a/jobs/cf_exporter/spec
+++ b/jobs/cf_exporter/spec
@@ -8,6 +8,9 @@ templates:
   bpm.yml.erb: config/bpm.yml
   web_tls_cert.pem.erb: config/web_tls_cert.pem
   web_tls_key.pem.erb: config/web_tls_key.pem
+  bbs_ca.pem.erb: config/bbs_ca.pem
+  bbs_cert.pem.erb: config/bbs_cert.pem
+  bbs_key.pem.erb: config/bbs_key.pem
 
 properties:
   cf_exporter.cf.api_url:

--- a/jobs/cf_exporter/spec
+++ b/jobs/cf_exporter/spec
@@ -54,6 +54,24 @@ properties:
   cf_exporter.web.tls_key:
     description: "TLS private key (PEM format)"
 
+
+  cf_exporter.bbs.api_url:
+    description: "BBS API URL"
+  cf_exporter.bbs.ca:
+    description: "CA certificate for BBS API"
+  cf_exporter.bbs.cert:
+    description: "Certificate for BBS API"
+  cf_exporter.bbs.key:
+    description: "Private key for BBS API"
+  cf_exporter.bbs.skip_ssl_verify:
+    description: "Disable SSL Verify for BBS"
+    default: false
+  cf_exporter.bbs.timeout:
+    description: "BBS API Timeout"
+    default: 30
+
+
+
   env.http_proxy:
     description: "HTTP proxy to use"
   env.https_proxy:

--- a/jobs/cf_exporter/templates/bbs_ca.pem.erb
+++ b/jobs/cf_exporter/templates/bbs_ca.pem.erb
@@ -1,0 +1,1 @@
+<%= p('cf_exporter.bbs.ca', '') %>

--- a/jobs/cf_exporter/templates/bbs_cert.pem.erb
+++ b/jobs/cf_exporter/templates/bbs_cert.pem.erb
@@ -1,0 +1,1 @@
+<%= p('cf_exporter.bbs.cert', '') %>

--- a/jobs/cf_exporter/templates/bbs_key.pem.erb
+++ b/jobs/cf_exporter/templates/bbs_key.pem.erb
@@ -1,0 +1,1 @@
+<%= p('cf_exporter.bbs.key', '') %>

--- a/jobs/cf_exporter/templates/bpm.yml.erb
+++ b/jobs/cf_exporter/templates/bpm.yml.erb
@@ -34,7 +34,7 @@ specMap.each { |specKey, envKey|
 
 
 # Configure BBS settings if api_url is provided
-if p("cf_exporter.bbs.api_url")
+if_p("cf_exporter.bbs.api_url")
   env["CF_EXPORTER_BBS_API_URL"]         = p("cf_exporter.bbs.api_url")
   env["CF_EXPORTER_BBS_CA_FILE"]         = "/var/vcap/jobs/cf_exporter/config/bbs_ca.pem"
   env["CF_EXPORTER_BBS_CERT_FILE"]       = "/var/vcap/jobs/cf_exporter/config/bbs_cert.pem"

--- a/jobs/cf_exporter/templates/bpm.yml.erb
+++ b/jobs/cf_exporter/templates/bpm.yml.erb
@@ -32,6 +32,18 @@ specMap.each { |specKey, envKey|
   end
 }
 
+
+# Configure BBS settings if api_url is provided
+if p("cf_exporter.bbs.api_url")
+  env["CF_EXPORTER_BBS_API_URL"]         = p("cf_exporter.bbs.api_url")
+  env["CF_EXPORTER_BBS_CA_FILE"]         = "/var/vcap/jobs/cf_exporter/config/bbs_ca.pem"
+  env["CF_EXPORTER_BBS_CERT_FILE"]       = "/var/vcap/jobs/cf_exporter/config/bbs_cert.pem"
+  env["CF_EXPORTER_BBS_KEY_FILE"]        = "/var/vcap/jobs/cf_exporter/config/bbs_key.pem"
+  env["CF_EXPORTER_BBS_SKIP_SSL_VERIFY"] = p("cf_exporter.bbs.skip_ssl_verify")
+  env["CF_EXPORTER_BBS_TIMEOUT"]         = p("cf_exporter.bbs.timeout")
+end
+
+
 # when property value is true
 # -> not "if property exists"
 # -> always defined since it has a default value in spec

--- a/jobs/cf_exporter/templates/bpm.yml.erb
+++ b/jobs/cf_exporter/templates/bpm.yml.erb
@@ -25,6 +25,9 @@ specMap = {
   "cf_exporter.metrics.namespace"   => "CF_EXPORTER_METRICS_NAMESPACE",
   "cf_exporter.metrics.environment" => "CF_EXPORTER_METRICS_ENVIRONMENT",
   "cf_exporter.web.telemetry_path"  => "CF_EXPORTER_WEB_TELEMETRY_PATH",
+  "cf_exporter.bbs.api_url"         => "CF_EXPORTER_BBS_API_URL",
+  "cf_exporter.bbs.skip_ssl_verify" => "CF_EXPORTER_BBS_SKIP_SSL_VERIFY",
+  "cf_exporter.bbs.timeout"         => "CF_EXPORTER_BBS_TIMEOUT"
 }
 specMap.each { |specKey, envKey|
   if_p(specKey) do |specValue|
@@ -34,14 +37,12 @@ specMap.each { |specKey, envKey|
 
 
 # Configure BBS settings if api_url is provided
-if_p("cf_exporter.bbs.api_url")
-  env["CF_EXPORTER_BBS_API_URL"]         = p("cf_exporter.bbs.api_url")
+if_p("cf_exporter.bbs.ca", "cf_exporter.bbs.cert", "cf_exporter.bbs.key") do
   env["CF_EXPORTER_BBS_CA_FILE"]         = "/var/vcap/jobs/cf_exporter/config/bbs_ca.pem"
   env["CF_EXPORTER_BBS_CERT_FILE"]       = "/var/vcap/jobs/cf_exporter/config/bbs_cert.pem"
   env["CF_EXPORTER_BBS_KEY_FILE"]        = "/var/vcap/jobs/cf_exporter/config/bbs_key.pem"
-  env["CF_EXPORTER_BBS_SKIP_SSL_VERIFY"] = p("cf_exporter.bbs.skip_ssl_verify")
-  env["CF_EXPORTER_BBS_TIMEOUT"]         = p("cf_exporter.bbs.timeout")
 end
+
 
 
 # when property value is true

--- a/jobs/prometheus/templates/config/prometheus.yml
+++ b/jobs/prometheus/templates/config/prometheus.yml
@@ -24,7 +24,7 @@ global:
   <% end %>
 
 # Rule files specifies a list of files from which rules are read.
-rule_files: <%= p('prometheus.rule_files', []).push('/var/vcap/jobs/prometheus2/config/custom.rules.yml').to_json %>
+rule_files: <%= p('prometheus.rule_files', []).push('/var/vcap/jobs/prometheus/config/custom.rules.yml').to_json %>
 
 # A list of scrape configurations.
 <% scrape_configs = p('prometheus.scrape_configs', []).map do |scrape_config|


### PR DESCRIPTION
Problems:

- In order to retrieve the metric `cf_application_instances_running` the `cf_exporter` needs to be configured to connect to BBS.  `cf_exporter` already supports scraping from BBS if certain environment variables are set, however the spec that configures this on the Prometheus side was missing.
- Custom rules are hard coded to look in `/var/vcap/jobs/prometheus2/config/custom.rules.yml` in `prometheus.yml` even though the file is rendered correctly to `/var/vcap/jobs/prometheus/config/custom.rules.yml`.  This results in the custom rules file being ignored. Referenced in issue https://github.com/cloudfoundry/prometheus-boshrelease/issues/580

Solutions:

 - Add new `cf_exporter.bbs.ca`, `cf_exporter.bbs.cert`, `cf_exporter.bbs.key` which are supplied from CF credhub variable `diego_bbs_client.ca`, `diego_bbs_client.certificate`, `diego_bbs_client.private_key`.  When combined with `diego_bbs_api_url` these are the 4 values required to have the cf_exporter scrape the BBS endpoint.
 - Fixing the hard coded path in `prometheus.yml` to point to the new job location with the renaming of jobs from Prometheus2 to Prometheus3
 
 