### PR TITLE
Upgrade kube-state-metrics to v2.18.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "src/github.com/kubernetes/kube-state-metrics"]
-	path = src/github.com/kubernetes/kube-state-metrics
-	url = https://github.com/kubernetes/kube-state-metrics

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -22,6 +22,7 @@
 | [jdbranham/diagram-panel] | grafana_plugings | v1.10.4  | ![][jdbranham/diagram-panel-ver] | ![][jdbranham/diagram-panel-act] |
 | [jq]                      | *internal*       | v1.8.1    | ![][jq-ver]                      | ![][jq-act]                      |
 | [kafka_exporter]          |                  | v1.9.0  | ![][kafka_exporter-ver]          | ![][kafka_exporter-act]          |
+| [kube-state-metrics]      | kubernetes       | v2.18.0 | ![][kube-state-metrics-ver]      | ![][kube-state-metrics-act]      |
 | [libxml2]                 | grafana          | v2.15.0 | ![][libxml2-ver]                 |                                  |
 | [logstash_exporter]       |                  | v0.7.15 | ![][logstash_exporter-ver]       | ![][logstash_exporter-act]       |
 | [memcached_exporter]      |                  | v0.16.0 | ![][memcached_exporter-ver]      | ![][memcached_exporter-act]      |
@@ -136,6 +137,9 @@
 [kafka_exporter]: https://github.com/danielqsj/kafka_exporter
 [kafka_exporter-act]: https://img.shields.io/github/release-date/danielqsj/kafka_exporter?label=latest
 [kafka_exporter-ver]: https://img.shields.io/github/v/release/danielqsj/kafka_exporter?label=latest
+[kube-state-metrics]: https://github.com/kubernetes/kube-state-metrics
+[kube-state-metrics-act]: https://img.shields.io/github/release-date/kubernetes/kube-state-metrics?label=latest
+[kube-state-metrics-ver]: https://img.shields.io/github/v/release/kubernetes/kube-state-metrics?label=latest
 [logstash_exporter]: https://github.com/SAP/prometheus-logstash-exporter
 [logstash_exporter-act]: https://img.shields.io/github/release-date/SAP/prometheus-logstash-exporter?label=latest
 [logstash_exporter-ver]: https://img.shields.io/github/v/release/SAP/prometheus-logstash-exporter?label=latest

--- a/ci/scripts/shipit
+++ b/ci/scripts/shipit
@@ -53,7 +53,6 @@ header() {
 
 header "Creating final release..."
 cd ${REPO_ROOT}
-git submodule update --init --recursive --force
 cat > config/private.yml <<EOF
 ---
 blobstore:

--- a/ci/scripts/testflight
+++ b/ci/scripts/testflight
@@ -56,7 +56,6 @@ bosh -n upload-stemcell ${STEMCELL}
 
 header "Creating candidate release..."
 cd ${REPO_ROOT}
-git submodule update --init --recursive --force
 cat > config/private.yml <<EOF
 ---
 blobstore:

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -114,6 +114,9 @@ kafka_exporter/kafka_exporter-1.9.0.linux-amd64.tar.gz:
   size: 12733803
   object_id: b72cc82a-ec34-43fc-5b4b-642d7b927bc5
   sha: sha256:c722518ad71c53b3988ea26ae2bd387bb596ce7a98fc639d08bf639a537699a1
+kube_state_metrics_exporter/kube-state-metrics_2.18.0_Linux_x86_64.tar.gz:
+  size: 18369951
+  sha: sha256:aaba5a752a6576196cdae91c438cbaaf5ba1fe50aca3d63c8a796178fb12ba2d
 libxml2/libxml2-2.15.0.tar.xz:
   size: 2004476
   object_id: be9065c9-f6b6-4a5f-7b22-5dc7ad1086d5

--- a/jobs/kube_state_metrics_exporter/spec
+++ b/jobs/kube_state_metrics_exporter/spec
@@ -17,23 +17,17 @@ consumes:
 properties:
   kube_state_metrics_exporter.apiserver:
     description: "The URL of the apiserver to use as a master"
-  kube_state_metrics_exporter.collectors:
-    description: "Comma-separated list of collectors to be enabled"
-  kube_state_metrics_exporter.disable_node_non_generic_resource_metrics:
-    description: "Disable node non generic resource request and limit metrics"
-  kube_state_metrics_exporter.disable_pod_non_generic_resource_metrics:
-    description: "Disable pod non generic resource request and limit metrics"
+  kube_state_metrics_exporter.resources:
+    description: "Comma-separated list of resources to be enabled"
   kube_state_metrics_exporter.kubeconfig:
     description: "Kubernetes configuration"
   kube_state_metrics_exporter.kubeconfig_tls_ca:
     description: "Kubernetes TLS CA (pem format)"
-  kube_state_metrics_exporter.log_backtrace_at:
-    description: "when logging hits line file:N, emit a stack trace (default :0)"
-  kube_state_metrics_exporter.metric_blacklist:
-    description: "Comma-separated list of metrics not to be enabled. The whitelist and blacklist are mutually exclusive"
-  kube_state_metrics_exporter.metric_whitelist:
-    description: "Comma-separated list of metrics to be exposed. The whitelist and blacklist are mutually exclusive"
-  kube_state_metrics_exporter.namespace:
+  kube_state_metrics_exporter.metric_denylist:
+    description: "Comma-separated list of metrics not to be enabled. The allowlist and denylist are mutually exclusive"
+  kube_state_metrics_exporter.metric_allowlist:
+    description: "Comma-separated list of metrics to be exposed. The allowlist and denylist are mutually exclusive"
+  kube_state_metrics_exporter.namespaces:
     description: "Comma-separated list of namespaces to be enabled"
   kube_state_metrics_exporter.port:
     description: "Port on which to expose metrics"

--- a/jobs/kube_state_metrics_exporter/templates/bin/kube_state_metrics_exporter_ctl
+++ b/jobs/kube_state_metrics_exporter/templates/bin/kube_state_metrics_exporter_ctl
@@ -38,32 +38,18 @@ case $1 in
       <% if_p('kube_state_metrics_exporter.apiserver') do |apiserver| %> \
       --apiserver="<%= apiserver %>" \
       <% end %> \
-      <% if_p('kube_state_metrics_exporter.collectors') do |collectors| %> \
-      --collectors="<%= collectors %>" \
-      <% end %> \
-      <% if_p('kube_state_metrics_exporter.disable_node_non_generic_resource_metrics') do |disable_node_non_generic_resource_metrics| %> \
-        <% if disable_node_non_generic_resource_metrics %> \
-      --disable-node-non-generic-resource-metrics="<%= collectors %>" \
-        <% end %> \
-      <% end %> \
-      <% if_p('kube_state_metrics_exporter.disable_pod_non_generic_resource_metrics') do |disable_pod_non_generic_resource_metrics| %> \
-        <% if disable_pod_non_generic_resource_metrics %> \
-      --disable-pod-non-generic-resource-metrics \
-        <% end %> \
+      <% if_p('kube_state_metrics_exporter.resources') do |resources| %> \
+      --resources="<%= resources %>" \
       <% end %> \
       --kubeconfig="/var/vcap/jobs/kube_state_metrics_exporter/config/kubeconfig" \
-      <% if_p('kube_state_metrics_exporter.log_backtrace_at') do |log_backtrace_at| %> \
-      --log_backtrace_at="<%= log_backtrace_at %>" \
+      <% if_p('kube_state_metrics_exporter.metric_denylist') do |metric_denylist| %> \
+      --metric-denylist="<%= metric_denylist %>" \
       <% end %> \
-      --log_dir=${LOG_DIR} \
-      <% if_p('kube_state_metrics_exporter.metric_blacklist') do |metric_blacklist| %> \
-      --metric-blacklist="<%= metric_blacklist %>" \
+      <% if_p('kube_state_metrics_exporter.metric_allowlist') do |metric_allowlist| %> \
+      --metric-allowlist="<%= metric_allowlist %>" \
       <% end %> \
-      <% if_p('kube_state_metrics_exporter.metric_whitelist') do |metric_whitelist| %> \
-      --metric-whitelist="<%= metric_whitelist %>" \
-      <% end %> \
-      <% if_p('kube_state_metrics_exporter.namespace') do |namespace| %> \
-      --namespace="<%= namespace %>" \
+      <% if_p('kube_state_metrics_exporter.namespaces') do |namespaces| %> \
+      --namespaces="<%= namespaces %>" \
       <% end %> \
       --port=<%= p('kube_state_metrics_exporter.port') %> \
       <% if_p('kube_state_metrics_exporter.stderrthreshold') do |stderrthreshold| %> \

--- a/packages/kube_state_metrics_exporter/packaging
+++ b/packages/kube_state_metrics_exporter/packaging
@@ -6,15 +6,7 @@ set -eux
 mkdir -p ${BOSH_INSTALL_TARGET}/common
 cp -a ${BOSH_COMPILE_TARGET}/common/* ${BOSH_INSTALL_TARGET}/common
 
-# Build kube_state_metrics_exporter package
-source /var/vcap/packages/golang-1-linux/bosh/compile.env
-
-SOURCE_DIR=github.com/kubernetes/kube-state-metrics
-PACKAGE_NAME=k8s.io/kube-state-metrics
-mkdir -p ${BOSH_INSTALL_TARGET}/src/${PACKAGE_NAME}
-cp -a ${BOSH_COMPILE_TARGET}/${SOURCE_DIR}/* ${BOSH_INSTALL_TARGET}/src/${PACKAGE_NAME}
-export GOPATH=${BOSH_INSTALL_TARGET}
-
-go install ${PACKAGE_NAME}
-
-rm -rf ${BOSH_INSTALL_TARGET}/pkg ${BOSH_INSTALL_TARGET}/src
+# Extract kube_state_metrics_exporter package
+mkdir -p ${BOSH_INSTALL_TARGET}/bin
+tar xzvf ${BOSH_COMPILE_TARGET}/kube_state_metrics_exporter/kube-state-metrics_2.18.0_Linux_x86_64.tar.gz
+cp -a ${BOSH_COMPILE_TARGET}/kube-state-metrics ${BOSH_INSTALL_TARGET}/bin

--- a/packages/kube_state_metrics_exporter/spec
+++ b/packages/kube_state_metrics_exporter/spec
@@ -1,9 +1,6 @@
 ---
 name: kube_state_metrics_exporter
 
-dependencies:
-  - golang-1-linux
-
 files:
   - common/utils.sh
-  - github.com/kubernetes/kube-state-metrics/**/*
+  - kube_state_metrics_exporter/kube-state-metrics_2.18.0_Linux_x86_64.tar.gz


### PR DESCRIPTION
Streamlines upgrades of `kube-state-metrics`.
Also includes some changes made in V2 of `kube-state-metrics`.