### PR TITLE
Fix latency dashboard buckets for Prometheus v3

### DIFF
--- a/jobs/cloudfoundry_dashboards/templates/cf_apps_latency.json
+++ b/jobs/cloudfoundry_dashboards/templates/cf_apps_latency.json
@@ -341,7 +341,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(rate(firehose_http_duration_seconds_bucket{le=\"1\", environment=~\"$environment\",application_id=~\"$cf_application_id\"}[5m])) by (le)  \n/ on()\nsum(rate(firehose_http_duration_seconds_count{environment=~\"$environment\",application_id=~\"$cf_application_id\"}[5m]))\n* 100",
+          "expr": "sum(rate(firehose_http_duration_seconds_bucket{le=~\"1([.]0)?\", environment=~\"$environment\",application_id=~\"$cf_application_id\"}[5m])) by (le)  \n/ on()\nsum(rate(firehose_http_duration_seconds_count{environment=~\"$environment\",application_id=~\"$cf_application_id\"}[5m]))\n* 100",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -367,7 +367,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(rate(firehose_http_duration_seconds_bucket{le=\"5\", environment=~\"$environment\",application_id=~\"$cf_application_id\"}[5m])) by (le)  \n/ on()\nsum(rate(firehose_http_duration_seconds_count{environment=~\"$environment\",application_id=~\"$cf_application_id\"}[5m]))\n* 100",
+          "expr": "sum(rate(firehose_http_duration_seconds_bucket{le=~\"5([.]0)?\", environment=~\"$environment\",application_id=~\"$cf_application_id\"}[5m])) by (le)  \n/ on()\nsum(rate(firehose_http_duration_seconds_count{environment=~\"$environment\",application_id=~\"$cf_application_id\"}[5m]))\n* 100",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -380,7 +380,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(rate(firehose_http_duration_seconds_bucket{le=\"10\", environment=~\"$environment\",application_id=~\"$cf_application_id\"}[5m])) by (le)  \n/ on()\nsum(rate(firehose_http_duration_seconds_count{environment=~\"$environment\",application_id=~\"$cf_application_id\"}[5m]))\n* 100",
+          "expr": "sum(rate(firehose_http_duration_seconds_bucket{le=~\"10([.]0)?\", environment=~\"$environment\",application_id=~\"$cf_application_id\"}[5m])) by (le)  \n/ on()\nsum(rate(firehose_http_duration_seconds_count{environment=~\"$environment\",application_id=~\"$cf_application_id\"}[5m]))\n* 100",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -664,7 +664,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(firehose_http_duration_seconds_bucket{le=\"1\", environment=~\"$environment\",application_id=~\"$cf_application_id\"}) by (le)  \n/ on()\nsum(firehose_http_duration_seconds_count{environment=~\"$environment\",application_id=~\"$cf_application_id\"})\n* 100",
+          "expr": "sum(firehose_http_duration_seconds_bucket{le=~\"1([.]0)?\", environment=~\"$environment\",application_id=~\"$cf_application_id\"}) by (le)  \n/ on()\nsum(firehose_http_duration_seconds_count{environment=~\"$environment\",application_id=~\"$cf_application_id\"})\n* 100",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -690,7 +690,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(firehose_http_duration_seconds_bucket{le=\"5\", environment=~\"$environment\",application_id=~\"$cf_application_id\"}) by (le)  \n/ on()\nsum(firehose_http_duration_seconds_count{environment=~\"$environment\",application_id=~\"$cf_application_id\"})\n* 100",
+          "expr": "sum(firehose_http_duration_seconds_bucket{le=~\"5([.]0)?\", environment=~\"$environment\",application_id=~\"$cf_application_id\"}) by (le)  \n/ on()\nsum(firehose_http_duration_seconds_count{environment=~\"$environment\",application_id=~\"$cf_application_id\"})\n* 100",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -703,7 +703,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(firehose_http_duration_seconds_bucket{le=\"10\", environment=~\"$environment\",application_id=~\"$cf_application_id\"}) by (le)  \n/ on()\nsum(firehose_http_duration_seconds_count{environment=~\"$environment\",application_id=~\"$cf_application_id\"})\n* 100",
+          "expr": "sum(firehose_http_duration_seconds_bucket{le=~\"10([.]0)?\", environment=~\"$environment\",application_id=~\"$cf_application_id\"}) by (le)  \n/ on()\nsum(firehose_http_duration_seconds_count{environment=~\"$environment\",application_id=~\"$cf_application_id\"})\n* 100",
           "format": "time_series",
           "hide": false,
           "interval": "",


### PR DESCRIPTION
## What broke

After upgrading to v31.x the Apps: Latency dashboard shows "No data" in the 1s, 5s and 10s panels. The other buckets (5ms up to 2.5s) keep working.

## Why

Prometheus v3 normalizes the `le` label values of classic histograms upon ingestion. A bucket that v2 stored as `le="1"` is now stored as `le="1.0"`. The dashboard queries look these buckets up by their exact old names, so they stop matching anything once the server is on v3. Bounds that already had a decimal point, like `le="0.5"` and `le="2.5"`, kept the same spelling. That is why only three panels broke.

The [Prometheus migration guide](https://prometheus.io/docs/prometheus/latest/migration/#le-and-quantile-label-values) covers this exact case and recommends fixing the references, which is what this change does.

## The fix

Replace the six exact matchers with a regex that accepts both spellings:

```
le="1"   ->   le=~"1([.]0)?"
```

This keeps the panels working on v30.x deployments, on v3 for new data, and on historical data from before an upgrade.

I used `[.]` instead of `\.` on purpose. It means a literal dot without needing a backslash. A backslash here would have to be escaped twice, once for JSON and once for the PromQL string, and that is easy to get wrong.

## Validation

Tested on a live v31.2.1 deployment (Prometheus 3.11.3, Grafana 11.6.14+security-01). All six panels render again, including history from before the upgrade. The only side effect is cosmetic. For a few minutes around the upgrade itself a panel may show the old and new series as duplicate legend entries until the stale one drops out.

<details>
<summary>Panel queries before and after, run through Grafana against Prometheus 3.11.3</summary>

The queries below were executed through the Grafana datasource against the live server. Dashboard variables were pinned to match-all values for the test, and the multi-line expressions are flattened to single lines. The 0.5 and 2.5 buckets are included on both sides to show the decimal bounds were never affected. The summary line counts every query in the dashboard, including the panels not shown here.

Before, with the exact matchers as shipped in v31.2.1:

```
DATA (1 series): sum(rate(firehose_http_duration_seconds_bucket{le="0.5", environment=~".*",application_id=~".*"}[5m])) by (le) / on() sum(rate(firehose_http_duration_seconds_count{environment=~".*",application_id=~".*"}[5m])) * 100
EMPTY:           sum(rate(firehose_http_duration_seconds_bucket{le="1", environment=~".*",application_id=~".*"}[5m])) by (le) / on() sum(rate(firehose_http_duration_seconds_count{environment=~".*",application_id=~".*"}[5m])) * 100
DATA (1 series): sum(rate(firehose_http_duration_seconds_bucket{le="2.5", environment=~".*",application_id=~".*"}[5m])) by (le) / on() sum(rate(firehose_http_duration_seconds_count{environment=~".*",application_id=~".*"}[5m])) * 100
EMPTY:           sum(rate(firehose_http_duration_seconds_bucket{le="5", environment=~".*",application_id=~".*"}[5m])) by (le) / on() sum(rate(firehose_http_duration_seconds_count{environment=~".*",application_id=~".*"}[5m])) * 100
EMPTY:           sum(rate(firehose_http_duration_seconds_bucket{le="10", environment=~".*",application_id=~".*"}[5m])) by (le) / on() sum(rate(firehose_http_duration_seconds_count{environment=~".*",application_id=~".*"}[5m])) * 100
DATA (1 series): sum(firehose_http_duration_seconds_bucket{le="0.5", environment=~".*",application_id=~".*"}) by (le) / on() sum(firehose_http_duration_seconds_count{environment=~".*",application_id=~".*"}) * 100
EMPTY:           sum(firehose_http_duration_seconds_bucket{le="1", environment=~".*",application_id=~".*"}) by (le) / on() sum(firehose_http_duration_seconds_count{environment=~".*",application_id=~".*"}) * 100
DATA (1 series): sum(firehose_http_duration_seconds_bucket{le="2.5", environment=~".*",application_id=~".*"}) by (le) / on() sum(firehose_http_duration_seconds_count{environment=~".*",application_id=~".*"}) * 100
EMPTY:           sum(firehose_http_duration_seconds_bucket{le="5", environment=~".*",application_id=~".*"}) by (le) / on() sum(firehose_http_duration_seconds_count{environment=~".*",application_id=~".*"}) * 100
EMPTY:           sum(firehose_http_duration_seconds_bucket{le="10", environment=~".*",application_id=~".*"}) by (le) / on() sum(firehose_http_duration_seconds_count{environment=~".*",application_id=~".*"}) * 100

Apps: Latency    data:14   empty:6    errors:0   skipped:0
```

After this patch:

```
DATA (1 series): sum(rate(firehose_http_duration_seconds_bucket{le="0.5", environment=~".*",application_id=~".*"}[5m])) by (le) / on() sum(rate(firehose_http_duration_seconds_count{environment=~".*",application_id=~".*"}[5m])) * 100
DATA (1 series): sum(rate(firehose_http_duration_seconds_bucket{le=~"1([.]0)?", environment=~".*",application_id=~".*"}[5m])) by (le) / on() sum(rate(firehose_http_duration_seconds_count{environment=~".*",application_id=~".*"}[5m])) * 100
DATA (1 series): sum(rate(firehose_http_duration_seconds_bucket{le="2.5", environment=~".*",application_id=~".*"}[5m])) by (le) / on() sum(rate(firehose_http_duration_seconds_count{environment=~".*",application_id=~".*"}[5m])) * 100
DATA (1 series): sum(rate(firehose_http_duration_seconds_bucket{le=~"5([.]0)?", environment=~".*",application_id=~".*"}[5m])) by (le) / on() sum(rate(firehose_http_duration_seconds_count{environment=~".*",application_id=~".*"}[5m])) * 100
DATA (1 series): sum(rate(firehose_http_duration_seconds_bucket{le=~"10([.]0)?", environment=~".*",application_id=~".*"}[5m])) by (le) / on() sum(rate(firehose_http_duration_seconds_count{environment=~".*",application_id=~".*"}[5m])) * 100
DATA (1 series): sum(firehose_http_duration_seconds_bucket{le="0.5", environment=~".*",application_id=~".*"}) by (le) / on() sum(firehose_http_duration_seconds_count{environment=~".*",application_id=~".*"}) * 100
DATA (1 series): sum(firehose_http_duration_seconds_bucket{le=~"1([.]0)?", environment=~".*",application_id=~".*"}) by (le) / on() sum(firehose_http_duration_seconds_count{environment=~".*",application_id=~".*"}) * 100
DATA (1 series): sum(firehose_http_duration_seconds_bucket{le="2.5", environment=~".*",application_id=~".*"}) by (le) / on() sum(firehose_http_duration_seconds_count{environment=~".*",application_id=~".*"}) * 100
DATA (1 series): sum(firehose_http_duration_seconds_bucket{le=~"5([.]0)?", environment=~".*",application_id=~".*"}) by (le) / on() sum(firehose_http_duration_seconds_count{environment=~".*",application_id=~".*"}) * 100
DATA (1 series): sum(firehose_http_duration_seconds_bucket{le=~"10([.]0)?", environment=~".*",application_id=~".*"}) by (le) / on() sum(firehose_http_duration_seconds_count{environment=~".*",application_id=~".*"}) * 100

Apps: Latency    data:20   empty:0    errors:0   skipped:0
```

</details>