### PR TITLE
Increase graceful shutdown timeout for prometheus/prometheus2 jobs

### DIFF
--- a/jobs/prometheus/monit
+++ b/jobs/prometheus/monit
@@ -1,5 +1,5 @@
 check process prometheus
   with pidfile /var/vcap/sys/run/prometheus/prometheus.pid
   start program "/var/vcap/jobs/prometheus/bin/prometheus_ctl start"
-  stop program "/var/vcap/jobs/prometheus/bin/prometheus_ctl stop"
+  stop program "/var/vcap/jobs/prometheus/bin/prometheus_ctl stop" with timeout <%= p('prometheus.stop_timeout') + 10 %> seconds
   group vcap

--- a/jobs/prometheus/monit
+++ b/jobs/prometheus/monit
@@ -1,5 +1,5 @@
 check process prometheus
   with pidfile /var/vcap/sys/run/prometheus/prometheus.pid
   start program "/var/vcap/jobs/prometheus/bin/prometheus_ctl start"
-  stop program "/var/vcap/jobs/prometheus/bin/prometheus_ctl stop" with timeout <%= p('prometheus.stop_timeout') + 10 %> seconds
+  stop program "/var/vcap/jobs/prometheus/bin/prometheus_ctl stop" with timeout <%= p('prometheus.stop_timeout') + p('prometheus.stop_timeout_extra') %> seconds
   group vcap

--- a/jobs/prometheus/spec
+++ b/jobs/prometheus/spec
@@ -61,6 +61,9 @@ properties:
   prometheus.enable_features:
     description: "List of features to enable"
     default: []
+  prometheus.stop_timeout:
+    description: "Seconds to wait for prometheus to shut down gracefully before sending SIGKILL"
+    default: 110
 
   prometheus.alertmanager.notification_queue_capacity:
     description: "The capacity of the queue for pending alert manager notifications"

--- a/jobs/prometheus/spec
+++ b/jobs/prometheus/spec
@@ -64,6 +64,9 @@ properties:
   prometheus.stop_timeout:
     description: "Seconds to wait for prometheus to shut down gracefully before sending SIGKILL"
     default: 110
+  prometheus.stop_timeout_extra:
+    description: "Additional seconds monit waits beyond stop_timeout before declaring the stop failed. Gives bosh-agent headroom so a slow graceful shutdown isn't reported as a failure."
+    default: 10
 
   prometheus.alertmanager.notification_queue_capacity:
     description: "The capacity of the queue for pending alert manager notifications"

--- a/jobs/prometheus/templates/bin/prometheus_ctl
+++ b/jobs/prometheus/templates/bin/prometheus_ctl
@@ -153,7 +153,7 @@ case $1 in
     ;;
 
   stop)
-    kill_and_wait ${PIDFILE}
+    kill_and_wait ${PIDFILE} <%= p('prometheus.stop_timeout') %>
     ;;
 
   *)

--- a/jobs/prometheus2/monit
+++ b/jobs/prometheus2/monit
@@ -1,5 +1,5 @@
 check process prometheus2
   with pidfile /var/vcap/sys/run/prometheus2/prometheus.pid
   start program "/var/vcap/jobs/prometheus2/bin/prometheus_ctl start"
-  stop program "/var/vcap/jobs/prometheus2/bin/prometheus_ctl stop"
+  stop program "/var/vcap/jobs/prometheus2/bin/prometheus_ctl stop" with timeout <%= p('prometheus.stop_timeout') + 10 %> seconds
   group vcap

--- a/jobs/prometheus2/monit
+++ b/jobs/prometheus2/monit
@@ -1,5 +1,5 @@
 check process prometheus2
   with pidfile /var/vcap/sys/run/prometheus2/prometheus.pid
   start program "/var/vcap/jobs/prometheus2/bin/prometheus_ctl start"
-  stop program "/var/vcap/jobs/prometheus2/bin/prometheus_ctl stop" with timeout <%= p('prometheus.stop_timeout') + 10 %> seconds
+  stop program "/var/vcap/jobs/prometheus2/bin/prometheus_ctl stop" with timeout <%= p('prometheus.stop_timeout') + p('prometheus.stop_timeout_extra') %> seconds
   group vcap

--- a/jobs/prometheus2/spec
+++ b/jobs/prometheus2/spec
@@ -61,6 +61,9 @@ properties:
   prometheus.enable_features:
     description: "List of features to enable"
     default: []
+  prometheus.stop_timeout:
+    description: "Seconds to wait for prometheus to shut down gracefully before sending SIGKILL"
+    default: 110
 
   prometheus.alertmanager.notification_queue_capacity:
     description: "The capacity of the queue for pending alert manager notifications"

--- a/jobs/prometheus2/spec
+++ b/jobs/prometheus2/spec
@@ -64,6 +64,9 @@ properties:
   prometheus.stop_timeout:
     description: "Seconds to wait for prometheus to shut down gracefully before sending SIGKILL"
     default: 110
+  prometheus.stop_timeout_extra:
+    description: "Additional seconds monit waits beyond stop_timeout before declaring the stop failed. Gives bosh-agent headroom so a slow graceful shutdown isn't reported as a failure."
+    default: 10
 
   prometheus.alertmanager.notification_queue_capacity:
     description: "The capacity of the queue for pending alert manager notifications"

--- a/jobs/prometheus2/templates/bin/prometheus_ctl
+++ b/jobs/prometheus2/templates/bin/prometheus_ctl
@@ -153,7 +153,7 @@ case $1 in
     ;;
 
   stop)
-    kill_and_wait ${PIDFILE}
+    kill_and_wait ${PIDFILE} <%= p('prometheus.stop_timeout') %>
     ;;
 
   *)


### PR DESCRIPTION
I noticed that in some cases 25s given to `prometheus` to shut down using any kind of `bosh stop` might be not enough. In this case further logic runs `kill -SIGKILL` against `prometheus` process. It also has some downsides:
- 25s + time used by `monit` and time used by `bosh-agent` together might overlap default `bosh-agent` timeout 30s, and bosh task fails in that case.
- killing `prometheus` process with -SIGKILL leads to data loss on big deployments, because `prometheus` was not able to flush all WAL chunks from memory to the disk.
- hard killing `prometheus` using -SIGKILL most likely would force `prometheus` to rebuild its WAL from scratch on the next boot.

There is no strict recommendations how much time `prometheus` might need for a proper graceful shutdown, especially in big environments.
- [Official Core behaviour:](https://prometheus.io/docs/prometheus/latest/management_api/#quit) Prometheus does not have an internal maximum shutdown timer flag, it will continue to run until it finishes flushing memory blocks and WAL segments to disk
- [Prometheus Kubernetes Operator](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#prometheusspec): PrometheusSpec defines default value for `terminationGracePeriodSeconds` to 600s.
- [Prometheus community kubernetes helm chart](https://github.com/prometheus-community/helm-charts/blob/f81cae2a3ce2c9a9771085abc1da79b7b2dcbd5b/charts/prometheus/values.yaml#L798) has the value of terminationGracePeriodSettings for the server set to 300s.

This PR increases time for a graceful shutdown from 25s to 110s. It also configures `bosh-agent` to wait 10s more than graceful shutdown is configured before reporting that the job failed. Current leftover 5s length is not always enough for bosh-agent. Updating it to 10s should be enough to never give up in most cases.

The PR also makes the graceful shutdown timeout configurable. 